### PR TITLE
Add Smudgeplot and GenomeScope Modules, and Genome Properties and Prepare Input workflows

### DIFF
--- a/modules/MODULE_TEMPLATE
+++ b/modules/MODULE_TEMPLATE
@@ -33,7 +33,7 @@ process TOOL_SUBTOOL {
         $reads
 
     cat <<-END_VERSIONS > versions.yml
-    ${task.process}:
+    '${task.process}':
         tool: \$( tool --version | sed '1 !d;s/[^0-9]*\\(\\([0-9]\\.\\)\\{0,4\\}[0-9][^.]\\).*/\\1/' )
     END_VERSIONS
     """

--- a/modules/MODULE_TEMPLATE
+++ b/modules/MODULE_TEMPLATE
@@ -1,7 +1,7 @@
 process TOOL_SUBTOOL {
 
     // TODO:: Update conda path to correct conda depedencies
-    conda "${task.ext.enable_conda ? 'bioconda::tool=0.0.0' : '' }"
+    conda "${params.enable_conda ? 'bioconda::tool=0.0.0' : '' }"
     // TODO:: Update Singularity and Docker paths to correct container paths
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
               'https://depot.galaxyproject.org/singularity/tool:0.0.0--0' :

--- a/modules/MODULE_TEMPLATE
+++ b/modules/MODULE_TEMPLATE
@@ -3,33 +3,38 @@ process TOOL_SUBTOOL {
     // TODO:: Update conda path to correct conda depedencies
     conda "${task.ext.enable_conda ? 'bioconda::tool=0.0.0' : '' }"
     // TODO:: Update Singularity and Docker paths to correct container paths
-    container "${workflow.containerEngine == 'singularity' &&
-                  !task.ext.singularity_pull_docker_container ?
+    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
               'https://depot.galaxyproject.org/singularity/tool:0.0.0--0' :
               'quay.io/biocontainers/tool:0.0.0--0' }"
 
-    // TODO:: Update inputs to allow all possible file inputs to be staged. 
-    //        When a file is optional, use [] to call the process. 
+    // TODO:: Update inputs to allow all possible file inputs to be staged.
+    //        When a file is optional, use [] to call the process.
     input:
     tuple val(meta), path(reads)
 
-    // TODO:: Update outputs for each desired output. 
+    // TODO:: Update outputs for each desired output.
     //        meta should be passed with each output to allow downstream processing
-    //        Each output channel should be named using the emit directive.  
+    //        Each output channel should be named using the emit directive.
     output:
-    tuple val(meta), path("outfile.txt"), emit: txt 
+    tuple val(meta), path("outfile.txt"), emit: txt
+    path "versions.yml"                 , emit: versions
 
-    // TODO:: Update script with command. 
+    // TODO:: Update script with command.
     //        Allow tool specific arguments to be passed using ext.args
     //        Allow tool output to be prefixed using $prefix
     script:
-    def prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}" 
-    def args   = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: meta.id
+    def args   = task.ext.args   ?: ''
     """
     tool subtool \\
         $args \\
         -o $prefix \\
         -t $task.cpus \\
         $reads
+
+    cat <<-END_VERSIONS > versions.yml
+    ${task.process}:
+        tool: \$( tool --version | sed '1 !d;s/[^0-9]*\(\([0-9]\.\)\{0,4\}[0-9][^.]\).*/\1/' )
+    END_VERSIONS
     """
 }

--- a/modules/MODULE_TEMPLATE
+++ b/modules/MODULE_TEMPLATE
@@ -34,7 +34,7 @@ process TOOL_SUBTOOL {
 
     cat <<-END_VERSIONS > versions.yml
     ${task.process}:
-        tool: \$( tool --version | sed '1 !d;s/[^0-9]*\(\([0-9]\.\)\{0,4\}[0-9][^.]\).*/\1/' )
+        tool: \$( tool --version | sed '1 !d;s/[^0-9]*\\(\\([0-9]\\.\\)\\{0,4\\}[0-9][^.]\\).*/\\1/' )
     END_VERSIONS
     """
 }

--- a/modules/genomescope/genomescope.nf
+++ b/modules/genomescope/genomescope.nf
@@ -28,7 +28,7 @@ process GENOMESCOPE {
 
     cat <<-END_VERSIONS > versions.yml
     '${task.process}':
-        tool: \$( genomescope2 -v | sed '1 !d;s/[^0-9]*\\(\\([0-9]\\.\\)\\{0,4\\}[0-9]\\).*/\\1/' )
+        genomescope2: \$( genomescope2 -v | sed '1 !d;s/[^0-9]*\\(\\([0-9]\\.\\)\\{0,4\\}[0-9]\\).*/\\1/' )
     END_VERSIONS
     """
 }

--- a/modules/genomescope/genomescope.nf
+++ b/modules/genomescope/genomescope.nf
@@ -1,6 +1,6 @@
 process GENOMESCOPE {
 
-    conda "${task.ext.enable_conda ? 'bioconda::genomescope2==2.0' : '' }"
+    conda "${params.enable_conda ? 'bioconda::genomescope2==2.0' : '' }"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
               'https://depot.galaxyproject.org/singularity/genomescope2:2.0--py39r40hdfd78af_4' :
               'quay.io/biocontainers/genomescope2:2.0--py39r40hdfd78af_4' }"

--- a/modules/genomescope/genomescope.nf
+++ b/modules/genomescope/genomescope.nf
@@ -9,17 +9,17 @@ process GENOMESCOPE {
     tuple val(meta), path(histogram)
 
     output:
-    tuple val(meta), path("*linear_plot.png")            , emit: linear_plot_png
-    tuple val(meta), path("*transformed_linear_plot.png"), emit: transformed_linear_plot_png
-    tuple val(meta), path("*log_plot.png")               , emit: log_plot_png
-    tuple val(meta), path("*transformed_log_plot.png")   , emit: transformed_log_plot_png
-    tuple val(meta), path("*model.txt")                  , emit: model
-    tuple val(meta), path("*summary.txt")                , emit: summary
-    path "versions.yml"                                  , emit: versions
+    tuple val(meta), path("$prefix/linear_plot.png")            , emit: linear_plot_png
+    tuple val(meta), path("$prefix/transformed_linear_plot.png"), emit: transformed_linear_plot_png
+    tuple val(meta), path("$prefix/log_plot.png")               , emit: log_plot_png
+    tuple val(meta), path("$prefix/transformed_log_plot.png")   , emit: transformed_log_plot_png
+    tuple val(meta), path("$prefix/model.txt")                  , emit: model
+    tuple val(meta), path("$prefix/summary.txt")                , emit: summary
+    path "versions.yml"                                         , emit: versions
 
     script:
-    def prefix = task.ext.prefix ?: meta.id
-    def args   = task.ext.args   ?: ''
+    prefix   = task.ext.prefix ?: meta.id
+    def args = task.ext.args   ?: ''
     """
     genomescope2 \\
         -i $histogram \\

--- a/modules/genomescope/genomescope.nf
+++ b/modules/genomescope/genomescope.nf
@@ -1,0 +1,34 @@
+process GENOMESCOPE {
+
+    conda "${task.ext.enable_conda ? 'bioconda::genomescope2==2.0' : '' }"
+    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+              'https://depot.galaxyproject.org/singularity/genomescope2:2.0--py39r40hdfd78af_4' :
+              'quay.io/biocontainers/genomescope2:2.0--py39r40hdfd78af_4' }"
+
+    input:
+    tuple val(meta), path(histogram)
+
+    output:
+    tuple val(meta), path("*linear_plot.png")            , emit: linear_plot_png
+    tuple val(meta), path("*transformed_linear_plot.png"), emit: transformed_linear_plot_png
+    tuple val(meta), path("*log_plot.png")               , emit: log_plot_png
+    tuple val(meta), path("*transformed_log_plot.png")   , emit: transformed_log_plot_png
+    tuple val(meta), path("*model.txt")                  , emit: model
+    tuple val(meta), path("*summary.txt")                , emit: summary
+    path "versions.yml"                                  , emit: versions
+
+    script:
+    def prefix = task.ext.prefix ?: meta.id
+    def args   = task.ext.args   ?: ''
+    """
+    genomescope2 \\
+        -i $histogram \\
+        $args \\
+        -o $prefix
+
+    cat <<-END_VERSIONS > versions.yml
+    ${task.process}:
+        tool: \$( genomescope2 -v | sed '1 !d;s/[^0-9]*\(\([0-9]\.\)\{0,4\}[0-9]\).*/\1/' )
+    END_VERSIONS
+    """
+}

--- a/modules/genomescope/genomescope.nf
+++ b/modules/genomescope/genomescope.nf
@@ -28,7 +28,7 @@ process GENOMESCOPE {
 
     cat <<-END_VERSIONS > versions.yml
     ${task.process}:
-        tool: \$( genomescope2 -v | sed '1 !d;s/[^0-9]*\(\([0-9]\.\)\{0,4\}[0-9]\).*/\1/' )
+        tool: \$( genomescope2 -v | sed '1 !d;s/[^0-9]*\\(\\([0-9]\\.\\)\\{0,4\\}[0-9]\\).*/\\1/' )
     END_VERSIONS
     """
 }

--- a/modules/genomescope/genomescope.nf
+++ b/modules/genomescope/genomescope.nf
@@ -27,7 +27,7 @@ process GENOMESCOPE {
         -o $prefix
 
     cat <<-END_VERSIONS > versions.yml
-    ${task.process}:
+    '${task.process}':
         tool: \$( genomescope2 -v | sed '1 !d;s/[^0-9]*\\(\\([0-9]\\.\\)\\{0,4\\}[0-9]\\).*/\\1/' )
     END_VERSIONS
     """

--- a/modules/inspector/inspector.nf
+++ b/modules/inspector/inspector.nf
@@ -1,7 +1,7 @@
 process INSPECTOR {
 
     // TODO:: Update conda path to correct conda depedencies
-    // conda "${task.ext.enable_conda ? 'bioconda::tool=0.0.0' : '' }"
+    // conda "${params.enable_conda ? 'bioconda::tool=0.0.0' : '' }"
     // TODO:: Update Singularity and Docker paths to correct container paths
     container 'ghcr.io/nbisweden/earth-biogenome-project-pilot/inspector:1.0'
     // container "${workflow.containerEngine == 'singularity' &&

--- a/modules/inspector/inspector.nf
+++ b/modules/inspector/inspector.nf
@@ -25,9 +25,9 @@ process INSPECTOR {
     path "versions.yml"                                     , emit: versions
 
     script:
-    prefix     = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"
-    def args   = task.ext.args ?: ''
-    def ref    = reference ? "--ref $reference" : ''
+    prefix   = task.ext.prefix ?: meta.id
+    def args = task.ext.args   ?: ''
+    def ref  = reference ? "--ref $reference" : ''
     """
     inspector.py \\
         $args \\
@@ -38,7 +38,7 @@ process INSPECTOR {
         $ref
 
     cat <<-END_VERSIONS > versions.yml
-    ${task.process.tokenize(':').last()}:
+    ${task.process}:
         inspector: \$( inspector.py --version |& sed 's/Inspector_v//' )
     END_VERSIONS
     """

--- a/modules/inspector/inspector.nf
+++ b/modules/inspector/inspector.nf
@@ -38,7 +38,7 @@ process INSPECTOR {
         $ref
 
     cat <<-END_VERSIONS > versions.yml
-    ${task.process}:
+    '${task.process}':
         inspector: \$( inspector.py --version |& sed 's/Inspector_v//' )
     END_VERSIONS
     """

--- a/modules/kat/kat_comp/kat_comp.nf
+++ b/modules/kat/kat_comp/kat_comp.nf
@@ -17,8 +17,8 @@ process KAT_COMP {
     path "versions.yml"                              , emit: versions
 
     script:
-    def prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"
-    def args   = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: meta.id
+    def args   = task.ext.args   ?: ''
     """
     kat comp \\
         -t $task.cpus \\
@@ -28,7 +28,7 @@ process KAT_COMP {
         $assembly
 
     cat <<-END_VERSIONS > versions.yml
-    ${task.process.tokenize(':').last()}:
+    ${task.process}:
         kat: \$( kat --version | sed 's/kat //' )
     END_VERSIONS
     """

--- a/modules/kat/kat_comp/kat_comp.nf
+++ b/modules/kat/kat_comp/kat_comp.nf
@@ -28,7 +28,7 @@ process KAT_COMP {
         $assembly
 
     cat <<-END_VERSIONS > versions.yml
-    ${task.process}:
+    '${task.process}':
         kat: \$( kat --version | sed 's/kat //' )
     END_VERSIONS
     """

--- a/modules/kat/kat_comp/kat_comp.nf
+++ b/modules/kat/kat_comp/kat_comp.nf
@@ -1,6 +1,6 @@
 process KAT_COMP {
 
-    conda "${task.ext.enable_conda ? 'bioconda::kat==2.4.2' : '' }"
+    conda "${params.enable_conda ? 'bioconda::kat==2.4.2' : '' }"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
               'https://depot.galaxyproject.org/singularity/kat:2.4.2--py38hfc5f9d8_2' :
               'quay.io/biocontainers/kat:2.4.2--py38hfc5f9d8_2' }"

--- a/modules/kmc/kmc_dump/kmc_dump.nf
+++ b/modules/kmc/kmc_dump/kmc_dump.nf
@@ -22,7 +22,7 @@ process KMC_DUMP {
         $prefix.${lower_bound}-${upper_bound}.hist
 
     cat <<-END_VERSIONS > versions.yml
-    ${task.process}:
+    '${task.process}':
         kmc_dump: \$( kmc_dump --version | sed '1 !d;s/[^0-9]*\\(\\([0-9]\\.\\)\\{0,4\\}[0-9][^.]\\).*/\\1/' )
     END_VERSIONS
     """

--- a/modules/kmc/kmc_dump/kmc_dump.nf
+++ b/modules/kmc/kmc_dump/kmc_dump.nf
@@ -1,0 +1,29 @@
+process KMC_DUMP {
+
+    conda "${task.ext.enable_conda ? 'bioconda::kmc==3.1.2rc1' : '' }"
+    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+              'https://depot.galaxyproject.org/singularity/kmc:3.1.2rc1--h2d02072_0' :
+              'quay.io/biocontainers/kmc:3.1.2rc1--h2d02072_0' }"
+
+    input:
+    tuple val(meta), path(count_db), val(interval)
+
+    output:
+    tuple val(meta), path("*.hist"), emit: histogram
+    path "versions.yml"            , emit: versions
+
+    script:
+    def prefix = task.ext.prefix ?: meta.id
+    def args   = task.ext.args   ?: ''
+    """
+    kmc_dump -ci${interval[0]} -cx${interval[1]} \\
+        $args \\
+        $count_db \\
+        $prefix.${interval[0]}-${interval[1]}.hist
+
+    cat <<-END_VERSIONS > versions.yml
+    ${task.process}:
+        kmc_dump: \$( kmc_dump --version | sed '1 !d;s/[^0-9]*\(\([0-9]\.\)\{0,4\}[0-9][^.]\).*/\1/' )
+    END_VERSIONS
+    """
+}

--- a/modules/kmc/kmc_dump/kmc_dump.nf
+++ b/modules/kmc/kmc_dump/kmc_dump.nf
@@ -6,7 +6,7 @@ process KMC_DUMP {
               'quay.io/biocontainers/kmc:3.1.2rc1--h2d02072_0' }"
 
     input:
-    tuple val(meta), path(count_db), val(interval)
+    tuple val(meta), path(count_db), val(lower_bound), val(upper_bound)
 
     output:
     tuple val(meta), path("*.hist"), emit: histogram
@@ -16,10 +16,10 @@ process KMC_DUMP {
     def prefix = task.ext.prefix ?: meta.id
     def args   = task.ext.args   ?: ''
     """
-    kmc_dump -ci${interval[0]} -cx${interval[1]} \\
+    kmc_dump -ci${lower_bound} -cx${upper_bound} \\
         $args \\
-        $count_db \\
-        $prefix.${interval[0]}-${interval[1]}.hist
+        $prefix \\
+        $prefix.${lower_bound}-${upper_bound}.hist
 
     cat <<-END_VERSIONS > versions.yml
     ${task.process}:

--- a/modules/kmc/kmc_dump/kmc_dump.nf
+++ b/modules/kmc/kmc_dump/kmc_dump.nf
@@ -23,7 +23,7 @@ process KMC_DUMP {
 
     cat <<-END_VERSIONS > versions.yml
     ${task.process}:
-        kmc_dump: \$( kmc_dump --version | sed '1 !d;s/[^0-9]*\(\([0-9]\.\)\{0,4\}[0-9][^.]\).*/\1/' )
+        kmc_dump: \$( kmc_dump --version | sed '1 !d;s/[^0-9]*\\(\\([0-9]\\.\\)\\{0,4\\}[0-9][^.]\\).*/\\1/' )
     END_VERSIONS
     """
 }

--- a/modules/kmc/kmc_dump/kmc_dump.nf
+++ b/modules/kmc/kmc_dump/kmc_dump.nf
@@ -1,6 +1,6 @@
 process KMC_DUMP {
 
-    conda "${task.ext.enable_conda ? 'bioconda::kmc==3.1.2rc1' : '' }"
+    conda "${params.enable_conda ? 'bioconda::kmc==3.1.2rc1' : '' }"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
               'https://depot.galaxyproject.org/singularity/kmc:3.1.2rc1--h2d02072_0' :
               'quay.io/biocontainers/kmc:3.1.2rc1--h2d02072_0' }"

--- a/modules/kmc/kmc_hist/kmc_hist.nf
+++ b/modules/kmc/kmc_hist/kmc_hist.nf
@@ -30,7 +30,7 @@ process KMC_HIST {
         histogram ${prefix}.hist
 
     cat <<-END_VERSIONS > versions.yml
-    ${task.process}:
+    '${task.process}':
         kmc: \$( kmc --version | sed '1 !d;s/[^0-9]*\\(\\([0-9]\\.\\)\\{0,4\\}[0-9][^.]\\).*/\\1/' )
     END_VERSIONS
     """

--- a/modules/kmc/kmc_hist/kmc_hist.nf
+++ b/modules/kmc/kmc_hist/kmc_hist.nf
@@ -31,7 +31,7 @@ process KMC_HIST {
 
     cat <<-END_VERSIONS > versions.yml
     ${task.process}:
-        kmc: \$( kmc --version | sed '1 !d;s/[^0-9]*\(\([0-9]\.\)\{0,4\}[0-9][^.]\).*/\1/' )
+        kmc: \$( kmc --version | sed '1 !d;s/[^0-9]*\\(\\([0-9]\\.\\)\\{0,4\\}[0-9][^.]\\).*/\\1/' )
     END_VERSIONS
     """
 }

--- a/modules/kmc/kmc_hist/kmc_hist.nf
+++ b/modules/kmc/kmc_hist/kmc_hist.nf
@@ -1,0 +1,37 @@
+process KMC_HIST {
+
+    conda "${task.ext.enable_conda ? 'bioconda::kmc==3.1.2rc1' : '' }"
+    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+              'https://depot.galaxyproject.org/singularity/kmc:3.1.2rc1--h2d02072_0' :
+              'quay.io/biocontainers/kmc:3.1.2rc1--h2d02072_0' }"
+
+    input:
+    tuple val(meta), path(reads)
+
+    output:
+    tuple val(meta), path("$prefix"), emit: count_db
+    tuple val(meta), path("*.hist") , emit: histogram
+    path "versions.yml"             , emit: versions
+
+    script:
+    prefix   = task.ext.prefix ?: meta.id
+    def args = task.ext.args   ?: ''
+    """
+    mkdir kmc_workdir
+    printf '%s\n' $reads > kmc_read_files.txt
+    kmc $args \\
+        -t$task.cpus \\
+        -j$prefix.summary.json \\
+        @kmc_read_files.txt \\
+        $prefix \\
+        kmc_workdir
+    kmc_tools transform \\
+        $prefix \\
+        histogram ${prefix}.hist
+
+    cat <<-END_VERSIONS > versions.yml
+    ${task.process}:
+        kmc: \$( kmc --version | sed '1 !d;s/[^0-9]*\(\([0-9]\.\)\{0,4\}[0-9][^.]\).*/\1/' )
+    END_VERSIONS
+    """
+}

--- a/modules/kmc/kmc_hist/kmc_hist.nf
+++ b/modules/kmc/kmc_hist/kmc_hist.nf
@@ -1,6 +1,6 @@
 process KMC_HIST {
 
-    conda "${task.ext.enable_conda ? 'bioconda::kmc==3.1.2rc1' : '' }"
+    conda "${params.enable_conda ? 'bioconda::kmc==3.1.2rc1' : '' }"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
               'https://depot.galaxyproject.org/singularity/kmc:3.1.2rc1--h2d02072_0' :
               'quay.io/biocontainers/kmc:3.1.2rc1--h2d02072_0' }"

--- a/modules/kmc/kmc_hist/kmc_hist.nf
+++ b/modules/kmc/kmc_hist/kmc_hist.nf
@@ -9,7 +9,7 @@ process KMC_HIST {
     tuple val(meta), path(reads)
 
     output:
-    tuple val(meta), path("$prefix"), emit: count_db
+    tuple val(meta), path("*.kmc_{pre,suf}"), emit: count_db
     tuple val(meta), path("*.hist") , emit: histogram
     path "versions.yml"             , emit: versions
 
@@ -18,10 +18,10 @@ process KMC_HIST {
     def args = task.ext.args   ?: ''
     """
     mkdir kmc_workdir
-    printf '%s\n' $reads > kmc_read_files.txt
+    printf '%s\\n' $reads > kmc_read_files.txt
     kmc $args \\
         -t$task.cpus \\
-        -j$prefix.summary.json \\
+        -j${prefix}.summary.json \\
         @kmc_read_files.txt \\
         $prefix \\
         kmc_workdir

--- a/modules/smudgeplot/smudgeplot_cutoff/smudgeplot_cutoff.nf
+++ b/modules/smudgeplot/smudgeplot_cutoff/smudgeplot_cutoff.nf
@@ -1,0 +1,27 @@
+process SMUDGEPLOT_CUTOFF {
+
+    conda "${task.ext.enable_conda ? 'bioconda::smudgeplot==0.2.4' : '' }"
+    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+              'https://depot.galaxyproject.org/singularity/smudgeplot:0.2.4--py39r40h779adbc_1' :
+              'quay.io/biocontainers/smudgeplot:0.2.4--py39r40h779adbc_1' }"
+
+    input:
+    tuple val(meta), path(histogram)
+
+    output:
+    tuple val(meta), env([LOWER_BOUND, UPPER_BOUND]), emit: bounds
+    path "versions.yml"                             , emit: versions
+
+    script:
+    // def prefix = task.ext.prefix ?: meta.id
+    // def args   = task.ext.args   ?: ''
+    """
+    LOWER_BOUND=\$( smudgeplot.py cutoff $histogram L )
+    UPPER_BOUND=\$( smudgeplot.py cutoff $histogram U )
+
+    cat <<-END_VERSIONS > versions.yml
+    ${task.process}:
+        tool: \$( smudgeplot.py -v |& sed '1 !d;s/[^0-9]*\(\([0-9]\.\)\{0,4\}[0-9]\).*/\1/' )
+    END_VERSIONS
+    """
+}

--- a/modules/smudgeplot/smudgeplot_cutoff/smudgeplot_cutoff.nf
+++ b/modules/smudgeplot/smudgeplot_cutoff/smudgeplot_cutoff.nf
@@ -9,8 +9,8 @@ process SMUDGEPLOT_CUTOFF {
     tuple val(meta), path(histogram)
 
     output:
-    tuple val(meta), env([LOWER_BOUND, UPPER_BOUND]), emit: bounds
-    path "versions.yml"                             , emit: versions
+    tuple val(meta), env(LOWER_BOUND), env(UPPER_BOUND), emit: bounds
+    path "versions.yml"                                , emit: versions
 
     script:
     // def prefix = task.ext.prefix ?: meta.id
@@ -21,7 +21,7 @@ process SMUDGEPLOT_CUTOFF {
 
     cat <<-END_VERSIONS > versions.yml
     ${task.process}:
-        tool: \$( smudgeplot.py -v |& sed '1 !d;s/[^0-9]*\(\\([0-9]\\.\\)\\{0,4\\}[0-9]\\).*/\\1/' )
+        smudgeplot: \$( smudgeplot.py -v |& sed '1 !d;s/[^0-9]*\\(\\([0-9]\\.\\)\\{0,4\\}[0-9]\\).*/\\1/' )
     END_VERSIONS
     """
 }

--- a/modules/smudgeplot/smudgeplot_cutoff/smudgeplot_cutoff.nf
+++ b/modules/smudgeplot/smudgeplot_cutoff/smudgeplot_cutoff.nf
@@ -21,7 +21,7 @@ process SMUDGEPLOT_CUTOFF {
 
     cat <<-END_VERSIONS > versions.yml
     ${task.process}:
-        tool: \$( smudgeplot.py -v |& sed '1 !d;s/[^0-9]*\(\([0-9]\.\)\{0,4\}[0-9]\).*/\1/' )
+        tool: \$( smudgeplot.py -v |& sed '1 !d;s/[^0-9]*\(\\([0-9]\\.\\)\\{0,4\\}[0-9]\\).*/\\1/' )
     END_VERSIONS
     """
 }

--- a/modules/smudgeplot/smudgeplot_cutoff/smudgeplot_cutoff.nf
+++ b/modules/smudgeplot/smudgeplot_cutoff/smudgeplot_cutoff.nf
@@ -20,7 +20,7 @@ process SMUDGEPLOT_CUTOFF {
     UPPER_BOUND=\$( smudgeplot.py cutoff $histogram U )
 
     cat <<-END_VERSIONS > versions.yml
-    ${task.process}:
+    '${task.process}':
         smudgeplot: \$( smudgeplot.py -v |& sed '1 !d;s/[^0-9]*\\(\\([0-9]\\.\\)\\{0,4\\}[0-9]\\).*/\\1/' )
     END_VERSIONS
     """

--- a/modules/smudgeplot/smudgeplot_cutoff/smudgeplot_cutoff.nf
+++ b/modules/smudgeplot/smudgeplot_cutoff/smudgeplot_cutoff.nf
@@ -1,6 +1,6 @@
 process SMUDGEPLOT_CUTOFF {
 
-    conda "${task.ext.enable_conda ? 'bioconda::smudgeplot==0.2.4' : '' }"
+    conda "${params.enable_conda ? 'bioconda::smudgeplot==0.2.4' : '' }"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
               'https://depot.galaxyproject.org/singularity/smudgeplot:0.2.4--py39r40h779adbc_1' :
               'quay.io/biocontainers/smudgeplot:0.2.4--py39r40h779adbc_1' }"

--- a/modules/smudgeplot/smudgeplot_hetkmers/smudgeplot_hetkmers.nf
+++ b/modules/smudgeplot/smudgeplot_hetkmers/smudgeplot_hetkmers.nf
@@ -20,7 +20,7 @@ process SMUDGEPLOT_HETKMERS {
         -o $prefix < $histogram
 
     cat <<-END_VERSIONS > versions.yml
-    ${task.process}:
+    '${task.process}':
         smudgeplot: \$(smudgeplot.py -v |& sed '1 !d;s/[^0-9]*\\(\\([0-9]\\.\\)\\{0,4\\}[0-9]\\).*/\\1/' )
     END_VERSIONS
     """

--- a/modules/smudgeplot/smudgeplot_hetkmers/smudgeplot_hetkmers.nf
+++ b/modules/smudgeplot/smudgeplot_hetkmers/smudgeplot_hetkmers.nf
@@ -21,7 +21,7 @@ process SMUDGEPLOT_HETKMERS {
 
     cat <<-END_VERSIONS > versions.yml
     ${task.process}:
-        tool: \$(smudgeplot.py -v |& sed '1 !d;s/[^0-9]*\(\([0-9]\.\)\{0,4\}[0-9]\).*/\1/' )
+        tool: \$(smudgeplot.py -v |& sed '1 !d;s/[^0-9]*\\(\\([0-9]\\.\\)\\{0,4\\}[0-9]\\).*/\\1/' )
     END_VERSIONS
     """
 }

--- a/modules/smudgeplot/smudgeplot_hetkmers/smudgeplot_hetkmers.nf
+++ b/modules/smudgeplot/smudgeplot_hetkmers/smudgeplot_hetkmers.nf
@@ -1,0 +1,27 @@
+process SMUDGEPLOT_HETKMERS {
+
+    conda "${task.ext.enable_conda ? 'bioconda::smudgeplot==0.2.4' : '' }"
+    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+              'https://depot.galaxyproject.org/singularity/smudgeplot:0.2.4--py39r40h779adbc_1' :
+              'quay.io/biocontainers/smudgeplot:0.2.4--py39r40h779adbc_1' }"
+
+    input:
+    tuple val(meta), path(histogram)
+
+    output:
+    tuple val(meta), path("_coverages.tsv"), emit: coverage_tsv
+    path "versions.yml"                    , emit: versions
+
+    script:
+    def prefix = task.ext.prefix ?: meta.id
+    // def args   = task.ext.args   ?: ''
+    """
+    smudgeplot.py hetkmers \\
+        -o $prefix < $histogram
+
+    cat <<-END_VERSIONS > versions.yml
+    ${task.process}:
+        tool: \$(smudgeplot.py -v |& sed '1 !d;s/[^0-9]*\(\([0-9]\.\)\{0,4\}[0-9]\).*/\1/' )
+    END_VERSIONS
+    """
+}

--- a/modules/smudgeplot/smudgeplot_hetkmers/smudgeplot_hetkmers.nf
+++ b/modules/smudgeplot/smudgeplot_hetkmers/smudgeplot_hetkmers.nf
@@ -1,6 +1,6 @@
 process SMUDGEPLOT_HETKMERS {
 
-    conda "${task.ext.enable_conda ? 'bioconda::smudgeplot==0.2.4' : '' }"
+    conda "${params.enable_conda ? 'bioconda::smudgeplot==0.2.4' : '' }"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
               'https://depot.galaxyproject.org/singularity/smudgeplot:0.2.4--py39r40h779adbc_1' :
               'quay.io/biocontainers/smudgeplot:0.2.4--py39r40h779adbc_1' }"

--- a/modules/smudgeplot/smudgeplot_hetkmers/smudgeplot_hetkmers.nf
+++ b/modules/smudgeplot/smudgeplot_hetkmers/smudgeplot_hetkmers.nf
@@ -9,8 +9,8 @@ process SMUDGEPLOT_HETKMERS {
     tuple val(meta), path(histogram)
 
     output:
-    tuple val(meta), path("_coverages.tsv"), emit: coverage_tsv
-    path "versions.yml"                    , emit: versions
+    tuple val(meta), path("*_coverages.tsv"), emit: coverage_tsv
+    path "versions.yml"                     , emit: versions
 
     script:
     def prefix = task.ext.prefix ?: meta.id
@@ -21,7 +21,7 @@ process SMUDGEPLOT_HETKMERS {
 
     cat <<-END_VERSIONS > versions.yml
     ${task.process}:
-        tool: \$(smudgeplot.py -v |& sed '1 !d;s/[^0-9]*\\(\\([0-9]\\.\\)\\{0,4\\}[0-9]\\).*/\\1/' )
+        smudgeplot: \$(smudgeplot.py -v |& sed '1 !d;s/[^0-9]*\\(\\([0-9]\\.\\)\\{0,4\\}[0-9]\\).*/\\1/' )
     END_VERSIONS
     """
 }

--- a/modules/smudgeplot/smudgeplot_plot/smudgeplot_plot.nf
+++ b/modules/smudgeplot/smudgeplot_plot/smudgeplot_plot.nf
@@ -24,7 +24,7 @@ process SMUDGEPLOT_PLOT {
         $coverage
 
     cat <<-END_VERSIONS > versions.yml
-    ${task.process}:
+    '${task.process}':
         smudgeplot: \$( smudgeplot.py -v |& sed '1 !d;s/[^0-9]*\\(\\([0-9]\\.\\)\\{0,4\\}[0-9]\\).*/\\1/' )
     END_VERSIONS
     """

--- a/modules/smudgeplot/smudgeplot_plot/smudgeplot_plot.nf
+++ b/modules/smudgeplot/smudgeplot_plot/smudgeplot_plot.nf
@@ -1,6 +1,6 @@
 process SMUDGEPLOT_PLOT {
 
-    conda "${task.ext.enable_conda ? 'bioconda::smudgeplot==0.2.4' : '' }"
+    conda "${params.enable_conda ? 'bioconda::smudgeplot==0.2.4' : '' }"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
               'https://depot.galaxyproject.org/singularity/smudgeplot:0.2.4--py39r40h779adbc_1' :
               'quay.io/biocontainers/smudgeplot:0.2.4--py39r40h779adbc_1' }"

--- a/modules/smudgeplot/smudgeplot_plot/smudgeplot_plot.nf
+++ b/modules/smudgeplot/smudgeplot_plot/smudgeplot_plot.nf
@@ -25,7 +25,7 @@ process SMUDGEPLOT_PLOT {
 
     cat <<-END_VERSIONS > versions.yml
     ${task.process}:
-        tool: \$( smudgeplot.py -v |& sed '1 !d;s/[^0-9]*\\(\\([0-9]\\.\\)\\{0,4\\}[0-9]\\).*/\\1/' )
+        smudgeplot: \$( smudgeplot.py -v |& sed '1 !d;s/[^0-9]*\\(\\([0-9]\\.\\)\\{0,4\\}[0-9]\\).*/\\1/' )
     END_VERSIONS
     """
 }

--- a/modules/smudgeplot/smudgeplot_plot/smudgeplot_plot.nf
+++ b/modules/smudgeplot/smudgeplot_plot/smudgeplot_plot.nf
@@ -1,0 +1,31 @@
+process SMUDGEPLOT_PLOT {
+
+    conda "${task.ext.enable_conda ? 'bioconda::smudgeplot==0.2.4' : '' }"
+    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+              'https://depot.galaxyproject.org/singularity/smudgeplot:0.2.4--py39r40h779adbc_1' :
+              'quay.io/biocontainers/smudgeplot:0.2.4--py39r40h779adbc_1' }"
+
+    input:
+    tuple val(meta), path(coverage)
+
+    output:
+    tuple val(meta), path("*_smudgeplot.png")      , emit: smudgeplot_png
+    tuple val(meta), path("*_smudgeplot_log10.png"), emit: logsmudgeplot_png
+    tuple val(meta), path("*__summary_table.tsv")  , emit: summary_tsv
+    path "versions.yml"                            , emit: versions
+
+    script:
+    def prefix = task.ext.prefix ?: meta.id
+    def args   = task.ext.args   ?: ''
+    """
+    smudgeplot.py plot \\
+        -o $prefix \\
+        $args \\
+        $coverage
+
+    cat <<-END_VERSIONS > versions.yml
+    ${task.process}:
+        tool: \$( smudgeplot.py -v |& sed '1 !d;s/[^0-9]*\(\([0-9]\.\)\{0,4\}[0-9]\).*/\1/' )
+    END_VERSIONS
+    """
+}

--- a/modules/smudgeplot/smudgeplot_plot/smudgeplot_plot.nf
+++ b/modules/smudgeplot/smudgeplot_plot/smudgeplot_plot.nf
@@ -25,7 +25,7 @@ process SMUDGEPLOT_PLOT {
 
     cat <<-END_VERSIONS > versions.yml
     ${task.process}:
-        tool: \$( smudgeplot.py -v |& sed '1 !d;s/[^0-9]*\(\([0-9]\.\)\{0,4\}[0-9]\).*/\1/' )
+        tool: \$( smudgeplot.py -v |& sed '1 !d;s/[^0-9]*\\(\\([0-9]\\.\\)\\{0,4\\}[0-9]\\).*/\\1/' )
     END_VERSIONS
     """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -26,6 +26,9 @@ params {
     // General module configuration
     multiqc_config = "$baseDir/configs/multiqc_conf.yaml"
 
+    // Conda
+    enable_conda = false
+
     // Uppmax specific configuration
     project = ''
     clusterOptions = ''

--- a/subworkflows/genome_properties/genome_properties.nf
+++ b/subworkflows/genome_properties/genome_properties.nf
@@ -35,14 +35,14 @@ workflow GENOME_PROPERTIES {
     SMUDGEPLOT_CUTOFF ( KMC_HIST.out.histogram )
     KMC_DUMP ( KMC_HIST.out.count_db.join( SMUDGEPLOT_CUTOFF.out.bounds ) )
     SMUDGEPLOT_HETKMERS ( KMC_DUMP.out.histogram )
-    // SMUDGEPLOT_PLOT ( SMUDGEPLOT_HETKMERS.out.coverage_tsv )
+    SMUDGEPLOT_PLOT ( SMUDGEPLOT_HETKMERS.out.coverage_tsv )
 
     versions_ch = KMC_HIST.out.versions.first().mix(
         KMC_DUMP.out.versions.first(),
         GENOMESCOPE.out.versions.first(),
         SMUDGEPLOT_CUTOFF.out.versions.first(),
         SMUDGEPLOT_HETKMERS.out.versions.first(),
-        //SMUDGEPLOT_PLOT.out.versions.first()
+        SMUDGEPLOT_PLOT.out.versions.first()
     )
 
 }

--- a/subworkflows/genome_properties/genome_properties.nf
+++ b/subworkflows/genome_properties/genome_properties.nf
@@ -10,7 +10,10 @@ include { SMUDGEPLOT_HETKMERS } from "../../modules/smudgeplot/smudgeplot_hetkme
 include { SMUDGEPLOT_PLOT     } from "../../modules/smudgeplot/smudgeplot_plot/smudgeplot_plot"
 
 workflow {
-    GENOME_PROPERTIES ( Channel.fromPath( params.reads ) )
+    GENOME_PROPERTIES (
+        Channel.fromPath( params.reads )
+            .map{ file -> [ [ id:'test'], file ] }
+    )
 }
 
 workflow GENOME_PROPERTIES {
@@ -29,17 +32,17 @@ workflow GENOME_PROPERTIES {
     GENOMESCOPE ( KMC_HIST.out.histogram )
 
     // Generate Smudgeplot
-    SMUDGEPLOT_CUTOFF ( KMC_HIST.out.count_db )
+    SMUDGEPLOT_CUTOFF ( KMC_HIST.out.histogram )
     KMC_DUMP ( KMC_HIST.out.count_db.join( SMUDGEPLOT_CUTOFF.out.bounds ) )
     SMUDGEPLOT_HETKMERS ( KMC_DUMP.out.histogram )
-    SMUDGEPLOT_PLOT ( SMUDGEPLOT_HETKMERS.out.coverage_tsv )
+    // SMUDGEPLOT_PLOT ( SMUDGEPLOT_HETKMERS.out.coverage_tsv )
 
     versions_ch = KMC_HIST.out.versions.first().mix(
         KMC_DUMP.out.versions.first(),
         GENOMESCOPE.out.versions.first(),
         SMUDGEPLOT_CUTOFF.out.versions.first(),
         SMUDGEPLOT_HETKMERS.out.versions.first(),
-        SMUDGEPLOT_PLOT.out.versions.first()
+        //SMUDGEPLOT_PLOT.out.versions.first()
     )
 
 }

--- a/subworkflows/genome_properties/genome_properties.nf
+++ b/subworkflows/genome_properties/genome_properties.nf
@@ -9,11 +9,11 @@ include { SMUDGEPLOT_CUTOFF   } from "../../modules/smudgeplot/smudgeplot_cutoff
 include { SMUDGEPLOT_HETKMERS } from "../../modules/smudgeplot/smudgeplot_hetkmers/smudgeplot_hetkmers"
 include { SMUDGEPLOT_PLOT     } from "../../modules/smudgeplot/smudgeplot_plot/smudgeplot_plot"
 
+include { PREPARE_INPUT       } from "../../subworkflows/prepare_input/prepare_input"
+
 workflow {
-    GENOME_PROPERTIES (
-        Channel.fromPath( params.reads )
-            .map{ file -> [ [ id:'test'], file ] }
-    )
+    PREPARE_INPUT ( params.input )
+    GENOME_PROPERTIES ( PREPARE_INPUT.out.hifi )
 }
 
 workflow GENOME_PROPERTIES {

--- a/subworkflows/genome_properties/genome_properties.nf
+++ b/subworkflows/genome_properties/genome_properties.nf
@@ -1,0 +1,45 @@
+#! /usr/bin/env nextflow
+
+nextflow.enable.dsl = 2
+
+include { KMC_HIST            } from "../../modules/kmc/kmc_hist/kmc_hist"
+include { KMC_DUMP            } from "../../modules/kmc/kmc_dump/kmc_dump"
+include { GENOMESCOPE         } from "../../modules/genomescope/genomescope"
+include { SMUDGEPLOT_CUTOFF   } from "../../modules/smudgeplot/smudgeplot_cutoff/smudgeplot_cutoff"
+include { SMUDGEPLOT_HETKMERS } from "../../modules/smudgeplot/smudgeplot_hetkmers/smudgeplot_hetkmers"
+include { SMUDGEPLOT_PLOT     } from "../../modules/smudgeplot/smudgeplot_plot/smudgeplot_plot"
+
+workflow {
+    GENOME_PROPERTIES ( Channel.fromPath( params.reads ) )
+}
+
+workflow GENOME_PROPERTIES {
+
+    take:
+    reads_ch  // input type: [ [ id: 'sample_name' ], [ file('path/to/reads') ] ]
+
+    /* Genome properties workflow:
+        - Estimate genome depth of coverage from reads
+        - Generate k-mer histogram
+        - Smudgeplot
+    */
+    main:
+    // Generate GenomeScope Profile
+    KMC_HIST ( reads_ch )
+    GENOMESCOPE ( KMC_HIST.out.histogram )
+
+    // Generate Smudgeplot
+    SMUDGEPLOT_CUTOFF ( KMC_HIST.out.count_db )
+    KMC_DUMP ( KMC_HIST.out.count_db.join( SMUDGEPLOT_CUTOFF.out.bounds ) )
+    SMUDGEPLOT_HETKMERS ( KMC_DUMP.out.histogram )
+    SMUDGEPLOT_PLOT ( SMUDGEPLOT_HETKMERS.out.coverage_tsv )
+
+    versions_ch = KMC_HIST.out.versions.first().mix(
+        KMC_DUMP.out.versions.first(),
+        GENOMESCOPE.out.versions.first(),
+        SMUDGEPLOT_CUTOFF.out.versions.first(),
+        SMUDGEPLOT_HETKMERS.out.versions.first(),
+        SMUDGEPLOT_PLOT.out.versions.first()
+    )
+
+}

--- a/subworkflows/genome_properties/genome_properties.nf
+++ b/subworkflows/genome_properties/genome_properties.nf
@@ -45,4 +45,7 @@ workflow GENOME_PROPERTIES {
         SMUDGEPLOT_PLOT.out.versions.first()
     )
 
+    emit:
+    versions = versions_ch
+
 }

--- a/subworkflows/prepare_input/prepare_input.nf
+++ b/subworkflows/prepare_input/prepare_input.nf
@@ -1,0 +1,78 @@
+#! /usr/bin/env nextflow
+
+import org.yaml.snakeyaml.Yaml
+
+nextflow.enable.dsl = 2
+
+workflow {
+    PREPARE_INPUT()
+}
+
+/* params.input example sample sheet (samplesheet.yml)
+```yaml
+sample:
+  id: ERGA_Artic_Fox
+assembly:
+  - id: assemblerX_build1
+    path: /path/to/assembly
+  - id: assemblerY_build1
+    path: /path/to/assembly
+hic:
+  - /path/to/reads
+hifi:
+  - /path/to/reads
+rnaseq:
+  - /path/to/reads
+isoseq:
+  - /path/to/reads
+```
+leads to the following YAML data structure
+[
+    sample:[
+        id:ERGA_Artic_Fox
+    ],
+    assembly:[
+        [
+            id:assemblerX_build1,
+            path:/path/to/assembly
+        ],
+        [
+            id:assemblerY_build1,
+            path:/path/to/assembly
+        ]
+    ],
+    hic:[
+        /path/to/reads
+    ],
+    hifi:[
+        /path/to/reads
+    ],
+    rnaseq:[
+        /path/to/reads
+    ],
+    isoseq:[
+        /path/to/reads
+    ]
+]
+*/
+
+workflow PREPARE_INPUT {
+
+    Channel.fromPath( params.input )
+        .map { file -> readYAML( file ) }
+        .multiMap { data ->
+            assembly_ch : !data.assembly ?: [ data.sample, data.assembly ]
+            hic_ch      : !data.hic      ?: [ data.sample, data.hic.collect { file( it, checkIfExists: true ) } ]
+            hifi_ch     : !data.hifi     ?: [ data.sample, data.hifi.collect { file( it, checkIfExists: true ) } ]
+            rnaseq_ch   : !data.rnaseq   ?: [ data.sample, data.rnaseq.collect { file( it, checkIfExists: true ) } ]
+            isoseq_ch   : !data.isoseq   ?: [ data.sample, data.isoseq.collect { file( it, checkIfExists: true ) } ]
+        }
+        .set{ input }
+    input.assembly_ch.transpose()
+
+}
+
+def readYAML( yamlfile ) {
+    // TODO: Validate sample file
+    return new Yaml().load( new FileReader( yamlfile.toString() ) )
+}

--- a/subworkflows/prepare_input/prepare_input.nf
+++ b/subworkflows/prepare_input/prepare_input.nf
@@ -68,7 +68,9 @@ workflow PREPARE_INPUT {
             isoseq_ch   : !data.isoseq   ?: [ data.sample, data.isoseq.collect { file( it, checkIfExists: true ) } ]
         }
         .set{ input }
-    input.assembly_ch.transpose()
+    input.assembly_ch.transpose()     // Data is [ sample, [id:'assemblerX_build1', path:'/path/to/assembly']]
+        .map { sample, assembly -> [ sample, [ id: assembly.id, path: file( assembly.path, checkIfExists: true ) ] ] }
+        .set { assembly_ch }
 
 }
 

--- a/subworkflows/prepare_input/prepare_input.nf
+++ b/subworkflows/prepare_input/prepare_input.nf
@@ -5,7 +5,7 @@ import org.yaml.snakeyaml.Yaml
 nextflow.enable.dsl = 2
 
 workflow {
-    PREPARE_INPUT()
+    PREPARE_INPUT( params.input )
 }
 
 /* params.input example sample sheet (samplesheet.yml)
@@ -58,7 +58,11 @@ leads to the following YAML data structure
 
 workflow PREPARE_INPUT {
 
-    Channel.fromPath( params.input )
+    take:
+    infile
+
+    main:
+    Channel.fromPath( infile )
         .map { file -> readYAML( file ) }
         .multiMap { data ->
             assembly_ch : !data.assembly ?: [ data.sample, data.assembly ]
@@ -71,6 +75,13 @@ workflow PREPARE_INPUT {
     input.assembly_ch.transpose()     // Data is [ sample, [id:'assemblerX_build1', path:'/path/to/assembly']]
         .map { sample, assembly -> [ sample, [ id: assembly.id, path: file( assembly.path, checkIfExists: true ) ] ] }
         .set { assembly_ch }
+
+    emit:
+    assembly = assembly_ch
+    hic      = input.hic_ch
+    hifi     = input.hifi_ch
+    rnaseq   = input.rnaseq_ch
+    isoseq   = input.isoseq_ch
 
 }
 

--- a/tests/configs/test_data.config
+++ b/tests/configs/test_data.config
@@ -1,4 +1,4 @@
-// From Nf-core test datasets: last updated: 05/11/2021
+// From Nf-core test datasets: last updated: 03/12/2021
 
 // Base directory for test data
 def test_data_dir = "https://raw.githubusercontent.com/nf-core/test-datasets/modules/data"
@@ -36,6 +36,9 @@ params {
                 contigs_genome_maf_gz                          = "${test_data_dir}/genomics/sarscov2/genome/alignment/last/contigs.genome.maf.gz"
                 contigs_genome_par                             = "${test_data_dir}/genomics/sarscov2/genome/alignment/last/contigs.genome.par"
                 lastdb_tar_gz                                  = "${test_data_dir}/genomics/sarscov2/genome/alignment/last/lastdb.tar.gz"
+
+                baits_interval_list                            = "${test_data_dir}/genomics/sarscov2/genome/picard/baits.interval_list"
+                targets_interval_list                          = "${test_data_dir}/genomics/sarscov2/genome/picard/targets.interval_list"
             }
             'illumina' {
                 test_single_end_bam                            = "${test_data_dir}/genomics/sarscov2/illumina/bam/test.single_end.bam"
@@ -121,10 +124,16 @@ params {
                 gnomad_r2_1_1_vcf_gz_tbi                       = "${test_data_dir}/genomics/homo_sapiens/genome/vcf/gnomAD.r2.1.1.vcf.gz.tbi"
                 mills_and_1000g_indels_vcf_gz                  = "${test_data_dir}/genomics/homo_sapiens/genome/vcf/mills_and_1000G.indels.vcf.gz"
                 mills_and_1000g_indels_vcf_gz_tbi              = "${test_data_dir}/genomics/homo_sapiens/genome/vcf/mills_and_1000G.indels.vcf.gz.tbi"
+
                 syntheticvcf_short_vcf_gz                      = "${test_data_dir}/genomics/homo_sapiens/genome/vcf/syntheticvcf_short.vcf.gz"
                 syntheticvcf_short_vcf_gz_tbi                  = "${test_data_dir}/genomics/homo_sapiens/genome/vcf/syntheticvcf_short.vcf.gz.tbi"
+
                 index_salmon                                   = "${test_data_dir}/genomics/homo_sapiens/genome/index/salmon"
                 repeat_expansions                              = "${test_data_dir}/genomics/homo_sapiens/genome/loci/repeat_expansions.json"
+                justhusky_ped                                  = "${test_data_dir}/genomics/homo_sapiens/genome/vcf/ped/justhusky.ped"
+                justhusky_minimal_vcf_gz                       = "${test_data_dir}/genomics/homo_sapiens/genome/vcf/ped/justhusky_minimal.vcf.gz"
+                justhusky_minimal_vcf_gz_tbi                   = "${test_data_dir}/genomics/homo_sapiens/genome/vcf/ped/justhusky_minimal.vcf.gz.tbi"
+
             }
             'illumina' {
                 test_paired_end_sorted_bam                              = "${test_data_dir}/genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam"
@@ -188,6 +197,8 @@ params {
                 test2_pileups_table                            = "${test_data_dir}/genomics/homo_sapiens/illumina/gatk/test2.pileups.table"
                 test_genomicsdb_tar_gz                         = "${test_data_dir}/genomics/homo_sapiens/illumina/gatk/test_genomicsdb.tar.gz"
 
+                test_genomicsdb_tar_gz                         = "${test_data_dir}/genomics/homo_sapiens/illumina/gatk/test_genomicsdb.tar.gz"
+
                 test_test2_paired_mutect2_calls_vcf_gz         = "${test_data_dir}/genomics/homo_sapiens/illumina/gatk/paired_mutect2_calls/test_test2_paired_mutect2_calls.vcf.gz"
                 test_test2_paired_mutect2_calls_vcf_gz_tbi     = "${test_data_dir}/genomics/homo_sapiens/illumina/gatk/paired_mutect2_calls/test_test2_paired_mutect2_calls.vcf.gz.tbi"
                 test_test2_paired_mutect2_calls_vcf_gz_stats   = "${test_data_dir}/genomics/homo_sapiens/illumina/gatk/paired_mutect2_calls/test_test2_paired_mutect2_calls.vcf.gz.stats"
@@ -212,8 +223,8 @@ params {
                 test_narrowpeak                                = "${test_data_dir}/genomics/homo_sapiens/illumina/narrowpeak/test.narrowPeak"
                 test2_narrowpeak                               = "${test_data_dir}/genomics/homo_sapiens/illumina/narrowpeak/test2.narrowPeak"
 
-                test_10x_1_fastq_gz                           = "${test_data_dir}/genomics/homo_sapiens/illumina/10xgenomics/test.10x_1.fastq.gz"
-                test_10x_2_fastq_gz                           = "${test_data_dir}/genomics/homo_sapiens/illumina/10xgenomics/test.10x_2.fastq.gz"
+                test_10x_1_fastq_gz                           = "${test_data_dir}/genomics/homo_sapiens/illumina/10xgenomics/test_10x_S1_L001_R1_001.fastq.gz"
+                test_10x_2_fastq_gz                           = "${test_data_dir}/genomics/homo_sapiens/illumina/10xgenomics/test_10x_S1_L001_R2_001.fastq.gz"
 
                 test_yak                                      = "${test_data_dir}/genomics/homo_sapiens/illumina/yak/test.yak"
                 test2_yak                                     = "${test_data_dir}/genomics/homo_sapiens/illumina/yak/test2.yak"
@@ -243,31 +254,84 @@ params {
                 filelist                                      = "${test_data_dir}/genomics/homo_sapiens/pacbio/txt/filelist.txt"
             }
         }
+        'bacteroides_fragilis' {
+            'genome' {
+                genome_fna_gz                   = "${test_data_dir}/genomics/prokaryotes/bacteroides_fragilis/genome/genome.fna.gz"
+                genome_paf                      = "${test_data_dir}/genomics/prokaryotes/bacteroides_fragilis/genome/genome.paf"
+            }
+            'illumina' {
+                test1_contigs_fa_gz             = "${test_data_dir}/genomics/prokaryotes/bacteroides_fragilis/illumina/fasta/test1.contigs.fa.gz"
+                test1_1_fastq_gz                = "${test_data_dir}/genomics/prokaryotes/bacteroides_fragilis/illumina/fastq/test1_1.fastq.gz"
+                test1_2_fastq_gz                = "${test_data_dir}/genomics/prokaryotes/bacteroides_fragilis/illumina/fastq/test1_2.fastq.gz"
+                test2_1_fastq_gz                = "${test_data_dir}/genomics/prokaryotes/bacteroides_fragilis/illumina/fastq/test2_1.fastq.gz"
+                test2_2_fastq_gz                = "${test_data_dir}/genomics/prokaryotes/bacteroides_fragilis/illumina/fastq/test2_2.fastq.gz"
+                test1_paired_end_bam            = "${test_data_dir}/genomics/prokaryotes/bacteroides_fragilis/illumina/bam/test1.bam"
+                test1_paired_end_sorted_bam     = "${test_data_dir}/genomics/prokaryotes/bacteroides_fragilis/illumina/bam/test1.sorted.bam"
+                test1_paired_end_sorted_bam_bai = "${test_data_dir}/genomics/prokaryotes/bacteroides_fragilis/illumina/bam/test1.sorted.bam.bai"
+                test2_paired_end_bam            = "${test_data_dir}/genomics/prokaryotes/bacteroides_fragilis/illumina/bam/test2.bam"
+                test2_paired_end_sorted_bam     = "${test_data_dir}/genomics/prokaryotes/bacteroides_fragilis/illumina/bam/test2.sorted.bam"
+                test2_paired_end_sorted_bam_bai = "${test_data_dir}/genomics/prokaryotes/bacteroides_fragilis/illumina/bam/test2.sorted.bam.bai"
+            }
+            'nanopore' {
+                test_fastq_gz                   = "${test_data_dir}/genomics/prokaryotes/bacteroides_fragilis/nanopore/fastq/test.fastq.gz"
+                overlap_paf                     = "${test_data_dir}/genomics/prokaryotes/bacteroides_fragilis/nanopore/overlap.paf"
+            }
+        }
+        'candidatus_portiera_aleyrodidarum' {
+            'genome' {
+                genome_fasta                    = "${test_data_dir}/genomics/prokaryotes/candidatus_portiera_aleyrodidarum/genome/genome.fasta"
+                genome_sizes                    = "${test_data_dir}/genomics/prokaryotes/candidatus_portiera_aleyrodidarum/genome/genome.sizes"
+                genome_aln_gz                   = "${test_data_dir}/genomics/prokaryotes/candidatus_portiera_aleyrodidarum/genome/genome.aln.gz"
+                genome_aln_nwk                  = "${test_data_dir}/genomics/prokaryotes/candidatus_portiera_aleyrodidarum/genome/genome.aln.nwk"
+                proteome_fasta                  = "${test_data_dir}/genomics/prokaryotes/candidatus_portiera_aleyrodidarum/genome/proteome.fasta"
+                test1_gff                       = "${test_data_dir}/genomics/prokaryotes/candidatus_portiera_aleyrodidarum/genome/gff/test1.gff"
+                test2_gff                       = "${test_data_dir}/genomics/prokaryotes/candidatus_portiera_aleyrodidarum/genome/gff/test2.gff"
+                test3_gff                       = "${test_data_dir}/genomics/prokaryotes/candidatus_portiera_aleyrodidarum/genome/gff/test3.gff"
+            }
+            'illumina' {
+                test_1_fastq_gz                 = "${test_data_dir}/genomics/prokaryotes/candidatus_portiera_aleyrodidarum/illumina/fasta/test_1.fastq.gz"
+                test_2_fastq_gz                 = "${test_data_dir}/genomics/prokaryotes/candidatus_portiera_aleyrodidarum/illumina/fastq/test_2.fastq.gz"
+                test_se_fastq_gz                = "${test_data_dir}/genomics/prokaryotes/candidatus_portiera_aleyrodidarum/illumina/fastq/test_se.fastq.gz"
+            }
+            'nanopore' {
+                test_fastq_gz                   = "${test_data_dir}/genomics/prokaryotes/candidatus_portiera_aleyrodidarum/nanopore/fastq/test.fastq.gz"
+            }
+        }
+        'haemophilus_influenzae' {
+            'genome' {
+                genome_fna_gz                   = "${test_data_dir}/genomics/prokaryotes/haemophilus_influenzae/genome/genome.fna.gz"
+                genome_aln_gz                   = "${test_data_dir}/genomics/prokaryotes/haemophilus_influenzae/genome/genome.aln.gz"
+                genome_aln_nwk                  = "${test_data_dir}/genomics/prokaryotes/haemophilus_influenzae/genome/genome.aln.nwk"
+            }
+        }
         'generic' {
+            'csv' {
+                test_csv = "${test_data_dir}/generic/csv/test.csv"
+            }
             'notebooks' {
                 rmarkdown = "${test_data_dir}/generic/notebooks/rmarkdown/rmarkdown_notebook.Rmd"
                 ipython_md = "${test_data_dir}/generic/notebooks/jupyter/ipython_notebook.md"
                 ipython_ipynb = "${test_data_dir}/generic/notebooks/jupyter/ipython_notebook.ipynb"
             }
+            'tsv' {
+                test_tsv = "${test_data_dir}/generic/tsv/test.tsv"
+            }
             'txt' {
                 hello = "${test_data_dir}/generic/txt/hello.txt"
             }
-        }
-        'bacteroides_fragilis'{
-            'genome' {
-                genome_fna_gz                   = "${test_data_dir}/genomics/bacteroides_fragilis/genome/genome.fna.gz"
-                genome_paf                      = "${test_data_dir}/genomics/bacteroides_fragilis/genome/genome.paf"
+            'cnn' {
+                 reference = "${test_data_dir}/generic/cnn/reference.cnn"
             }
-            'illumina' {
-                test1_contigs_fa_gz             = "${test_data_dir}/genomics/bacteroides_fragilis/illumina/fasta/test1.contigs.fa.gz"
-                test1_1_fastq_gz                = "${test_data_dir}/genomics/bacteroides_fragilis/illumina/fastq/test1_1.fastq.gz"
-                test1_2_fastq_gz                = "${test_data_dir}/genomics/bacteroides_fragilis/illumina/fastq/test1_2.fastq.gz"
-                test2_1_fastq_gz                = "${test_data_dir}/genomics/bacteroides_fragilis/illumina/fastq/test2_1.fastq.gz"
-                test2_2_fastq_gz                = "${test_data_dir}/genomics/bacteroides_fragilis/illumina/fastq/test2_2.fastq.gz"
-            }
-            'nanopore' {
-                test_fastq_gz                   = "${test_data_dir}/genomics/bacteroides_fragilis/nanopore/fastq/test.fastq.gz"
-                overlap_paf                     = "${test_data_dir}/genomics/bacteroides_fragilis/nanopore/overlap.paf"
+            'cooler'{
+                test_pairix_pair_gz                           = "${test_data_dir}/genomics/homo_sapiens/cooler/cload/hg19/hg19.GM12878-MboI.pairs.subsample.blksrt.txt.gz"
+                test_pairix_pair_gz_px2                       = "${test_data_dir}/genomics/homo_sapiens/cooler/cload/hg19/hg19.GM12878-MboI.pairs.subsample.blksrt.txt.gz.px2"
+                test_pairs_pair                               = "${test_data_dir}/genomics/homo_sapiens/cooler/cload/hg19/hg19.sample1.pairs"
+                test_tabix_pair_gz                            = "${test_data_dir}/genomics/homo_sapiens/cooler/cload/hg19/hg19.GM12878-MboI.pairs.subsample.sorted.possrt.txt.gz"
+                test_tabix_pair_gz_tbi                        = "${test_data_dir}/genomics/homo_sapiens/cooler/cload/hg19/hg19.GM12878-MboI.pairs.subsample.sorted.possrt.txt.gz.tbi"
+                hg19_chrom_sizes                              = "${test_data_dir}/genomics/homo_sapiens/cooler/cload/hg19/hg19.chrom.sizes"
+                test_merge_cool                               = "${test_data_dir}/genomics/homo_sapiens/cooler/merge/toy/toy.symm.upper.2.cool"
+                test_merge_cool_cp2                           = "${test_data_dir}/genomics/homo_sapiens/cooler/merge/toy/toy.symm.upper.2.cp2.cool"
+
             }
         }
     }


### PR DESCRIPTION
Add Modules for 
- KMC_HIST
- KMC_DUMP
- GENOMESCOPE
- SMUDGEPLOT_CUTOFF
- SMUDGEPLOT_HETKMERS
- SMUDGEPLOT_PLOT

Smudgeplot was separated into multiple modules because of the intertwined nature of the software calls. 

A Genome Properties subworkflow was developed as a result.
Also a subworkflow for preparing the input was also developed to allow a flexible way of parameterizing input. 

Edit: Also updated template to follow nf-core path of module formatting