### PR TITLE
Next update

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,16 +119,6 @@ Mandatory:
         read2: '/path/to/raw/data/rnaseq/LS_RNASEQ_R001_2.fastq.gz'
     isoseq:                          # Optional: List of Isoseq reads to use for validation
       - reads: '/path/to/raw/data/isoseq/LS_ISOSEQ_R001.bam'
-    settings:                        # Optional: Settings for workflow tools
-      # busco:
-        # lineages: 'fungi_odb10,eukaryota_odb10' # Optional. Comma separated list. (default: Automatically retrieved using GOAT)
-      fastk:
-        kmer_size: 31                # Optional: Select kmer size to use for Fastk database
-      genescopefk:
-        kmer_size: 31                # Optional: Select kmer size to use for GenescopeFK
-      hifiasm:                       # Optional: List of parameter settings to use.
-        - "--optsA 1 --optsB 2"
-        - "--optsA 3 --optsB 3"
     ```
 
 

--- a/README.md
+++ b/README.md
@@ -142,21 +142,21 @@ publishing method from the intermediate results folders
 
 Software specific:
 
-Software specific settings are included using the `settings` parameter. In the YAML file used as input
-to `-params-file`.
-```
+Tool specific settings are provided by supplying values to specific keys or supplying an array of
+settings under a tool name. The input to `-params-file` would look like this:
+
+```yml
 input: assembly.yml
 outdir: results
-settings:
-  fastk:
-    kmer_size: 31
-  genescopefk:
-    kmer_size: 31
-  hifiasm:
-    - "--opts A"
-    - "--opts B"
-  busco:
-    lineages: 'auto'
+fastk:
+  kmer_size: 31
+genescopefk:
+  kmer_size: 31
+hifiasm:
+  - "--opts A"
+  - "--opts B"
+busco:
+  lineages: 'auto'
 ```
 
 - `multiqc_config`: Path to MultiQC configuration file (default: `configs/multiqc_conf.yaml`).

--- a/README.md
+++ b/README.md
@@ -142,6 +142,23 @@ publishing method from the intermediate results folders
 
 Software specific:
 
+Software specific settings are included using the `settings` parameter. In the YAML file used as input
+to `-params-file`.
+```
+input: assembly.yml
+outdir: results
+settings:
+  fastk:
+    kmer_size: 31
+  genescopefk:
+    kmer_size: 31
+  hifiasm:
+    - "--opts A"
+    - "--opts B"
+  busco:
+    lineages: 'auto'
+```
+
 - `multiqc_config`: Path to MultiQC configuration file (default: `configs/multiqc_conf.yaml`).
 
 Uppmax cluster specific:

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ flowchart TD
     fastk_hifi --> hifiasm[[ HiFiasm ]]
     hifiasm --> assembly
     assembly --> purgedups[[ Purgedups ]]
+    assembly --> mitoref[[ Mitohifi - Find reference ]]
+    assembly --> mitohifi[[ Mitohifi ]]
+    mitoref --> mitohifi
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ Mandatory:
     ```yml
     sample:                          # Required: Meta data
       name: 'Laetiporus sulphureus'  # Required: Species name. Correct spelling is important to look up species information.
-      ploidy: 2                      # Required: Estimated ploidy of organism.
     assembly:                        # Optional: List of assemblies to curate and validate.
       - id: 'LS_phased_diploid'      # Each assembly has it's own ID. Assemblies can be primary and alternate or primary only
         pri_fasta: '/path/to/genome/primary.fasta'

--- a/configs/modules.config
+++ b/configs/modules.config
@@ -1,3 +1,15 @@
+stage {
+    inspect    = '01_read_inspection'
+    preprocess = '02_read_preprocessing'
+    assembly   = '03_assembly'
+    screen     = '04_contamination_screen'
+    purge      = '05_duplicate_purging'
+    polish     = '06_error_polishing'
+    scaffold   = '07_scaffolding'
+    curate     = '08_rapid_curation'
+    alignRNA   = '09_RNA_alignment'
+}
+
 process {
 
     // PREPARE INPUT
@@ -39,21 +51,21 @@ process {
             ].join(' ')
         }
         publishDir = [
-            path: { "$params.outdir/01_inspect_data/genescopefk" },
+            path: { "$params.outdir/$stage.inspect/genescopefk" },
             mode: params.publish_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
     withName: 'MERQURYFK_PLOIDYPLOT' {
         publishDir = [
-            path: { "$params.outdir/01_inspect_data/ploidyplot" },
+            path: { "$params.outdir/$stage.inspect/ploidyplot" },
             mode: params.publish_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
     withName: 'MERQURYFK_KATGC' {
         publishDir = [
-            path: { "$params.outdir/01_inspect_data/katgc" },
+            path: { "$params.outdir/$stage.inspect/katgc" },
             mode: params.publish_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -62,7 +74,7 @@ process {
     // COMPARE_LIBRARIES
     withName: 'MERQURYFK_KATCOMP' {
         publishDir = [
-            path: { "$params.outdir/01_inspect_data/kat_comp" },
+            path: { "$params.outdir/$stage.inspect/kat_comp" },
             mode: params.publish_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -73,7 +85,7 @@ process {
         ext.args   = '-w'
         ext.prefix = { "${meta.id}_${query.baseName}" }
         publishDir = [
-            path: { "$params.outdir/01_inspect_data/mash_screen/screens" },
+            path: { "$params.outdir/$stage.inspect/mash_screen/screens" },
             mode: params.publish_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -81,7 +93,7 @@ process {
     withName: 'MASH_FILTER' {
         ext.args   = "-F '[\\t/]' '\$1 > 0.9 && \$2 > 100'"
         publishDir = [
-            path: { "$params.outdir/01_inspect_data/mash_screen" },
+            path: { "$params.outdir/$stage.inspect/mash_screen" },
             mode: params.publish_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -92,7 +104,7 @@ process {
         tag        = { meta.assembly.build }
         ext.args   = { params.hifiasm ? params.hifiasm[task.index-1] : "" }
         publishDir = [
-            path: { "$params.outdir/03_assembly/$meta.assembly.build" },
+            path: { "$params.outdir/$stage.assembly/$meta.assembly.build" },
             mode: params.publish_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -100,7 +112,7 @@ process {
     withName: 'GFASTATS' {
         ext.prefix = { assembly.baseName }
         publishDir = [
-            path: { "$params.outdir/03_assembly/$meta.assembly.build" },
+            path: { "$params.outdir/$stage.assembly/$meta.assembly.build" },
             mode: params.publish_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -108,7 +120,7 @@ process {
     withName: 'GFATOOLS_GFA2FA' {
         ext.prefix = { gfa.baseName }
         publishDir = [
-            path: { "$params.outdir/03_assembly/$meta.assembly.build" },
+            path: { "$params.outdir/$stage.assembly/$meta.assembly.build" },
             mode: params.publish_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -117,7 +129,7 @@ process {
     // MITOHIFI
     withName: 'MITOHIFI_FINDMITOREFERENCE' {
         publishDir = [
-            path: { "$params.outdir/03_assembly/mitochondria/reference" },
+            path: { "$params.outdir/$stage.assembly/mitochondria/reference" },
             mode: params.publish_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -126,7 +138,7 @@ process {
         tag        = { meta.assembly.build }
         ext.prefix = { "${meta.id}-${meta.assembly.build}" }
         publishDir = [
-            path: { "$params.outdir/03_assembly/mitochondria/$meta.assembly.build" },
+            path: { "$params.outdir/$stage.assembly/mitochondria/$meta.assembly.build" },
             mode: params.publish_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -159,7 +171,7 @@ process {
     withName: 'PURGEDUPS_.*' {
         tag        = { meta.assembly.build }
         publishDir = [
-            path: { "$params.outdir/04_purge/purge_dups" },
+            path: { "$params.outdir/$stage.purge/purge_dups" },
             mode: params.publish_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]      
@@ -169,7 +181,7 @@ process {
     withName: 'QUAST' {
         cpus       = { Math.min(6, consensus instanceof List ? consensus.size() : 1 ) }
         publishDir = [
-            path: { "$params.outdir/04_purge/quast" },
+            path: { "$params.outdir/$stage.purge/quast" },
             mode: params.publish_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -180,7 +192,7 @@ process {
         tag        = { meta.assembly.build }
         ext.prefix = { meta.assembly.build }
         publishDir = [
-            path: { "$params.outdir/04_purge/merquryfk/$meta.assembly.build" },
+            path: { "$params.outdir/$stage.purge/merquryfk/$meta.assembly.build" },
             mode: params.publish_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -191,7 +203,7 @@ process {
         ext.prefix = { "${meta.assembly.build}-${lineage}" }
         ext.args   = '--tar'
         publishDir = [
-            path: { "$params.outdir/04_purge/busco/$meta.assembly.build" },
+            path: { "$params.outdir/$stage.purge/busco/$meta.assembly.build" },
             mode: params.publish_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -202,7 +214,7 @@ process {
         tag        = { meta.assembly.build }
         ext.args   = '--readFilesCommand zcat'
         publishDir = [
-            path: { "$params.outdir/rnaseq_alignment/star/$meta.assembly.build" },
+            path: { "$params.outdir/$stage.alignRNA/star/$meta.assembly.build" },
             mode: params.publish_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]

--- a/configs/modules.config
+++ b/configs/modules.config
@@ -122,6 +122,8 @@ process {
         ]
     }
     withName: 'MITOHIFI_MITOHIFI' {
+        // TODO:: Use build ID
+        ext.prefix = { "${meta.id}_${task.index}" }
         publishDir = [
             path: { "$params.outdir/03_assembly/mitochondria" },
             mode: params.publish_mode,

--- a/configs/modules.config
+++ b/configs/modules.config
@@ -3,7 +3,7 @@ process {
     // PREPARE INPUT
     withName: 'GOAT_TAXONSEARCH' {
         tag        = { meta.sample.name }
-        ext.args   = "--lineage --variables odb10_lineage"
+        ext.args   = "--lineage --variables odb10_lineage,chromosome_number,genome_size,ploidy"
     }
     withName: 'PREPARE_INPUT:SAMTOOLS_FASTA' {
         tag        = { "$meta.id:$bam.baseName" }

--- a/configs/modules.config
+++ b/configs/modules.config
@@ -89,6 +89,7 @@ process {
 
     // ASSEMBLE_HIFI
     withName: 'HIFIASM' {
+        tag        = { meta.assembly.build }
         ext.args   = { params.hifiasm ? params.hifiasm[task.index-1] : "" }
         publishDir = [
             path: { "$params.outdir/03_assembly/$meta.assembly.build" },
@@ -122,6 +123,7 @@ process {
         ]
     }
     withName: 'MITOHIFI_MITOHIFI' {
+        tag        = { meta.assembly.build }
         ext.prefix = { "${meta.id}-${meta.assembly.build}" }
         publishDir = [
             path: { "$params.outdir/03_assembly/mitochondria/$meta.assembly.build" },

--- a/configs/modules.config
+++ b/configs/modules.config
@@ -91,7 +91,7 @@ process {
     withName: 'HIFIASM' {
         ext.args   = { params.hifiasm ? params.hifiasm[task.index-1] : "" }
         publishDir = [
-            path: { "$params.outdir/03_assembly/hifiasm_${task.index}" },
+            path: { "$params.outdir/03_assembly/$meta.assembly.build" },
             mode: params.publish_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -99,7 +99,7 @@ process {
     withName: 'GFASTATS' {
         ext.prefix = { assembly.baseName }
         publishDir = [
-            path: { "$params.outdir/03_assembly/hifiasm_${task.index}" },
+            path: { "$params.outdir/03_assembly/$meta.assembly.build" },
             mode: params.publish_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -107,7 +107,7 @@ process {
     withName: 'GFATOOLS_GFA2FA' {
         ext.prefix = { gfa.baseName }
         publishDir = [
-            path: { "$params.outdir/03_assembly/hifiasm_${task.index}" },
+            path: { "$params.outdir/03_assembly/$meta.assembly.build" },
             mode: params.publish_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -122,10 +122,9 @@ process {
         ]
     }
     withName: 'MITOHIFI_MITOHIFI' {
-        // TODO:: Use build ID
-        ext.prefix = { "${meta.id}_${task.index}" }
+        ext.prefix = { "${meta.id}-${meta.assembly.build}" }
         publishDir = [
-            path: { "$params.outdir/03_assembly/mitochondria" },
+            path: { "$params.outdir/03_assembly/mitochondria/$meta.assembly.build" },
             mode: params.publish_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -133,11 +132,11 @@ process {
 
     // PURGE_DUPLICATES
     withName: 'MINIMAP2_ALIGN_READS' {
-        tag        = { meta.build }
+        tag        = { meta.assembly.build }
         ext.args   = "-x map-hifi"
     }
     withName: 'MINIMAP2_ALIGN_ASSEMBLY_.*' {
-        tag        = { meta.build }
+        tag        = { meta.assembly.build }
         ext.args   = "-x asm5 -DP"
     }
     withName: 'PURGEDUPS_PURGEDUPS' {
@@ -150,13 +149,13 @@ process {
         ext.args   = { meta.kmercov ? "-m ${meta.kmercov * 1.5} -u ${meta.kmercov * 3}" : "" }
     }
     withName: '(PURGEDUPS|MINIMAP2)_.*_PRIMARY' {
-        ext.prefix = { "${meta.id}_${meta.build}_primary" }
+        ext.prefix = { "${meta.id}_${meta.assembly.build}_primary" }
     }
     withName: '(PURGEDUPS|MINIMAP2)_.*_ALTERNATE' {
-        ext.prefix = { "${meta.id}_${meta.build}_alternate" }
+        ext.prefix = { "${meta.id}_${meta.assembly.build}_alternate" }
     }
     withName: 'PURGEDUPS_.*' {
-        tag        = { meta.build }
+        tag        = { meta.assembly.build }
         publishDir = [
             path: { "$params.outdir/04_purge/purge_dups" },
             mode: params.publish_mode,
@@ -176,21 +175,21 @@ process {
 
     // EVALUATE_ASSEMBLY
     withName: 'MERQURYFK_MERQURYFK' {
-        tag        = { meta.build }
-        ext.prefix = { meta.build }
+        tag        = { meta.assembly.build }
+        ext.prefix = { meta.assembly.build }
         publishDir = [
-            path: { "$params.outdir/04_purge/merquryfk/$meta.build" },
+            path: { "$params.outdir/04_purge/merquryfk/$meta.assembly.build" },
             mode: params.publish_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
 
     withName: 'BUSCO' {
-        tag        = { "${meta.build}-${lineage}" }
-        ext.prefix = { "${meta.build}-${lineage}" }
+        tag        = { "${meta.assembly.build}-${lineage}" }
+        ext.prefix = { "${meta.assembly.build}-${lineage}" }
         ext.args   = '--tar'
         publishDir = [
-            path: { "$params.outdir/04_purge/busco/$meta.build" },
+            path: { "$params.outdir/04_purge/busco/$meta.assembly.build" },
             mode: params.publish_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -198,10 +197,10 @@ process {
     }
 
     withName: 'STAR_ALIGN' {
-        tag        = { meta.build }
+        tag        = { meta.assembly.build }
         ext.args   = '--readFilesCommand zcat'
         publishDir = [
-            path: { "$params.outdir/rnaseq_alignment/star/$meta.build" },
+            path: { "$params.outdir/rnaseq_alignment/star/$meta.assembly.build" },
             mode: params.publish_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]

--- a/configs/modules.config
+++ b/configs/modules.config
@@ -13,7 +13,7 @@ process {
     // BUILD DATABASES
     withName: 'FASTK_FASTK' {
         scratch    = false  // Disable scratch to get around bug https://github.com/nextflow-io/nextflow/issues/2983
-        ext.args   = { "-t1 -k${meta.settings?.fastk?.kmer_size?:31}" }
+        ext.args   = { "-t1 -k${params.fastk?.kmer_size?:31}" }
     }
     withName: 'FASTK_MERGE' {
         scratch    = false  // Disable scratch to get around bug https://github.com/nextflow-io/nextflow/issues/2983
@@ -34,7 +34,7 @@ process {
     withName: 'GENESCOPEFK' {
         ext.args   = {
             [
-                "--kmer_length ${meta.settings?.genescopefk?.kmer_size?:31}",
+                "--kmer_length ${params.genescopefk?.kmer_size?:31}",
                 "--ploidy ${meta.sample.ploidy?:2}"
             ].join(' ')
         }
@@ -89,7 +89,7 @@ process {
 
     // HIFIASM
     withName: 'HIFIASM' {
-        ext.args   = { meta.settings?.hifiasm ? meta.settings.hifiasm[task.index-1] : "" }
+        ext.args   = { params.hifiasm ? params.hifiasm[task.index-1] : "" }
         publishDir = [
             path: { "$params.outdir/03_assembly/hifiasm_${task.index}" },
             mode: params.publish_mode,

--- a/configs/modules.config
+++ b/configs/modules.config
@@ -87,7 +87,7 @@ process {
         ]
     }
 
-    // HIFIASM
+    // ASSEMBLE_HIFI
     withName: 'HIFIASM' {
         ext.args   = { params.hifiasm ? params.hifiasm[task.index-1] : "" }
         publishDir = [
@@ -96,8 +96,6 @@ process {
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
-
-    // GFASTATS
     withName: 'GFASTATS' {
         ext.prefix = { assembly.baseName }
         publishDir = [
@@ -106,12 +104,26 @@ process {
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
-
-    // GFASTATS
     withName: 'GFATOOLS_GFA2FA' {
         ext.prefix = { gfa.baseName }
         publishDir = [
             path: { "$params.outdir/03_assembly/hifiasm_${task.index}" },
+            mode: params.publish_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    // MITOHIFI
+    withName: 'MITOHIFI_FINDMITOREFERENCE' {
+        publishDir = [
+            path: { "$params.outdir/03_assembly/mitochondria/reference" },
+            mode: params.publish_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+    withName: 'MITOHIFI_MITOHIFI' {
+        publishDir = [
+            path: { "$params.outdir/03_assembly/mitochondria" },
             mode: params.publish_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]

--- a/configs/nf-core-defaults.config
+++ b/configs/nf-core-defaults.config
@@ -15,15 +15,15 @@ process {
     withLabel: process_medium {
         cpus   = 6
         memory = 36.GB
-        time   = 8.h
+        time   = 24.h
     }
     withLabel: process_high {
         cpus   = 12
         memory = 72.GB
-        time   = 16.h
+        time   = 48.h
     }
     withLabel: process_long {
-        time   = 20.h
+        time   = 120.h
     }
     withLabel: process_high_memory {
         memory = 200.GB

--- a/main.nf
+++ b/main.nf
@@ -198,7 +198,7 @@ workflow {
         ALIGN_RNASEQ ( 
             PREPARE_INPUT.out.rnaseq,
             PREPARE_INPUT.out.assemblies
-                .map { meta, assembly -> [ meta + [ build: assembly.id ], assembly.pri_fasta ] }
+                .map { meta, assembly -> [ meta, assembly.pri_fasta ] }
         )
     }
 }

--- a/main.nf
+++ b/main.nf
@@ -67,9 +67,9 @@ workflow {
         'inspect',      // 01 - Read inspection
         'preprocess',   // 02 - Read preprocessing
         'assemble',     // 03 - Assembly
-        'purge',        // 04 - Duplicate purging
-        'polish',       // 05 - Error polishing
-        'screen',       // 06 - Contamination screening
+        'screen',       // 04 - Contamination screening
+        'purge',        // 05 - Duplicate purging
+        'polish',       // 06 - Error polishing
         'scaffold',     // 07 - Scaffolding
         'curate',       // 08 - Rapid curation
         'alignRNA'      // 09 - Align RNAseq data
@@ -159,9 +159,16 @@ workflow {
         )
     }
 
+    // Contamination screen
+    if ( 'screen' in workflow_steps ) {
+        // Kraken2
+        // Blobtoolkit
+        // FCS-Genome
+    }
+
     // Purge duplicates
     if ( 'purge' in workflow_steps ) {
-        ch_topurge = PREPARE_INPUT.out.hifi.combine( ch_assemblies, by:0 )
+        ch_topurge = PREPARE_INPUT.out.hifi.combine( ch_assemblies.filter { meta, assembly -> meta.assembly.stage in ['raw','decontaminated'] } , by:0 )
         if ( 'inspect' in workflow_steps ) {
             // Add kmer coverage from GenomeScope model
             ch_topurge.map { meta, reads, assemblies -> [ meta.findAll { ! (it.key in [ 'single_end' ]) }, reads, assemblies ] }
@@ -175,13 +182,6 @@ workflow {
     // Polish
     if ( 'polish' in workflow_steps ) {
         // Run polishers
-    }
-
-    // Contamination screen
-    if ( 'screen' in workflow_steps ) {
-        // Kraken2
-        // Blobtoolkit
-        // FCS-Genome
     }
 
     // Scaffold

--- a/main.nf
+++ b/main.nf
@@ -21,10 +21,43 @@ include { EVALUATE_ASSEMBLY  } from "$projectDir/subworkflows/local/evaluate_ass
 include { ALIGN_RNASEQ       } from "$projectDir/subworkflows/local/align_rnaseq/main"
 
 /*
-Class definitions
-Sample = [ id: id, kmer_size:2, ploidy:2, busco_lineage: auto ]
-Reads = [ Sample, [{r1,r2}/{bam}] ]
-Assembly = [ Sample, [id:id, pri_fasta:fasta, alt_fasta:fasta, pri_gfa:gfa, alt_gfa:gfa ] ]
+## Meta map key structures
+id = {sample.name/ /_}
+single_end = {*_reads.single_end}
+sample = [ 
+    name: <species name>,
+    genome_size: <GOAT>, 
+    ploidy: <GOAT>, 
+    chromosome_number: <GOAT>, 
+    busco_lineages: <GOAT> 
+]
+hifi_reads = [
+    single_end: true,
+    kmer_cov: <GENESCOPEFK>
+]
+hic_reads = [
+    single_end: false,
+    kmer_cov: <GENESCOPEFK>
+]
+rnaseq_reads = [
+    single_end: false
+]
+isoseq_reads = [
+    single_end: false
+]
+*/
+/*
+## Assembly record structure - Also merged to meta
+assembly = [
+    assembler: {hifiasm},
+    stage: {raw,decontaminated,deduplicated,polished,scaffolded,curated},
+    id: UUID
+    build: assembly.assembler-assembly.stage-assembly.id
+    pri_fasta: <ASSEMBLER>,
+    alt_fasta: null/<ASSEMBLER>,
+    pri_gfa: <ASSEMBLER>,
+    alt_gfa: null/<ASSEMBLER>
+]
 */
 
 workflow {

--- a/main.nf
+++ b/main.nf
@@ -74,7 +74,7 @@ workflow {
         SCREEN_READS ( 
             PREPARE_INPUT.out.hifi,
             // TODO:: Allow custom database ala nf-core/genomeassembler.
-            file( params.mash_screen_db, checkIfExists: true )
+            file( params.mash.screen_db, checkIfExists: true )
         )
     }
 
@@ -90,7 +90,7 @@ workflow {
         // Run in basic mode atm
         // Need to include a build ID here. 
         HIFIASM(
-            PREPARE_INPUT.out.hifi.flatMap { meta, reads -> meta.settings?.hifiasm ? meta.settings.hifiasm.collect { [ meta, reads ] } : [ [ meta, reads ] ] },
+            PREPARE_INPUT.out.hifi.flatMap { meta, reads -> params.hifiasm ? params.hifiasm.collect { [ meta, reads ] } : [ [ meta, reads ] ] },
             [], // paternal k-mers
             [], // maternal k-mers
             [], // Hi-C r1
@@ -137,7 +137,7 @@ workflow {
             PREPARE_INPUT.out.hifi,
             BUILD_HIFI_DATABASES.out.fastk_histogram.join( BUILD_HIFI_DATABASES.out.fastk_ktab ),
             params.reference ? file( params.reference, checkIfExists: true ) : [],
-            params.busco_lineage_path ? file( params.busco_lineage_path, checkIfExists: true ) : []
+            params.busco.lineages_db_path ? file( params.busco.lineages_db_path, checkIfExists: true ) : []
         )
     }
 

--- a/main.nf
+++ b/main.nf
@@ -122,7 +122,8 @@ workflow {
     if ( 'assemble' in workflow_steps ) {
         // Run assemblers
         ASSEMBLE_HIFI( PREPARE_INPUT.out.hifi )
-        ch_assemblies = ch_assemblies.mix( ASSEMBLE_HIFI.out.assemblies )
+        ch_assemblies = ch_assemblies.filter { meta, assembly -> meta.assembly.stage in ['raw'] }
+            .mix( ASSEMBLE_HIFI.out.assemblies )
 
         // Find mitochondria
         // Need to check options to mitohifi modules.

--- a/main.nf
+++ b/main.nf
@@ -93,10 +93,10 @@ workflow {
 
         // Find mitochondria
         // Need to check options to mitohifi modules.
-        MITOHIFI_FINDMITOREFERENCE( ch_assemblies.map { meta, assemblies -> [ meta, meta.sample.name ] } )
+        MITOHIFI_FINDMITOREFERENCE( ch_assemblies.map { meta, assemblies -> [ meta, meta.sample.name ] }.unique() )
         mitohifi_ch = ch_assemblies
-            .join( MITOHIFI_FINDMITOREFERENCE.out.fasta )
-            .join( MITOHIFI_FINDMITOREFERENCE.out.gb )
+            .combine( MITOHIFI_FINDMITOREFERENCE.out.fasta, by: 0 )
+            .combine( MITOHIFI_FINDMITOREFERENCE.out.gb, by: 0 )
             .multiMap { meta, assembly, mitofa, mitogb ->
                 input: [ meta, assembly.pri_fasta ]
                 reference: mitofa

--- a/modules.json
+++ b/modules.json
@@ -52,7 +52,7 @@
           },
           "hifiasm": {
             "branch": "master",
-            "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
+            "git_sha": "d6ca9eec4b2d52568022516405853444bde201f1",
             "installed_by": ["modules"]
           },
           "kraken2/kraken2": {

--- a/modules.json
+++ b/modules.json
@@ -87,12 +87,12 @@
           },
           "mitohifi/findmitoreference": {
             "branch": "master",
-            "git_sha": "f52220e84bfc16a8616a5bb3d6f5bc67d601bdce",
+            "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
             "installed_by": ["modules"]
           },
           "mitohifi/mitohifi": {
             "branch": "master",
-            "git_sha": "02c3c39e3d57bf77183e563598bae2ec1ec11cb1",
+            "git_sha": "5bcbc0c522879ba15a224eb06cd42e6c46932545",
             "installed_by": ["modules"]
           },
           "pilon": {

--- a/modules.json
+++ b/modules.json
@@ -93,7 +93,8 @@
           "mitohifi/mitohifi": {
             "branch": "master",
             "git_sha": "5bcbc0c522879ba15a224eb06cd42e6c46932545",
-            "installed_by": ["modules"]
+            "installed_by": ["modules"],
+            "patch": "modules/nf-core/mitohifi/mitohifi/mitohifi-mitohifi.diff"
           },
           "pilon": {
             "branch": "master",

--- a/modules/nf-core/hifiasm/environment.yml
+++ b/modules/nf-core/hifiasm/environment.yml
@@ -1,0 +1,7 @@
+name: hifiasm
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::hifiasm=0.19.8

--- a/modules/nf-core/hifiasm/main.nf
+++ b/modules/nf-core/hifiasm/main.nf
@@ -19,6 +19,7 @@ process HIFIASM {
     tuple val(meta), path("*.ec.bin")          , emit: corrected_reads
     tuple val(meta), path("*.ovlp.source.bin") , emit: source_overlaps
     tuple val(meta), path("*.ovlp.reverse.bin"), emit: reverse_overlaps
+    tuple val(meta), path("*.bp.p_ctg.gfa")    , emit: processed_contigs, optional: true
     tuple val(meta), path("*.p_utg.gfa")       , emit: processed_unitigs, optional: true
     tuple val(meta), path("*.asm.p_ctg.gfa")   , emit: primary_contigs  , optional: true
     tuple val(meta), path("*.asm.a_ctg.gfa")   , emit: alternate_contigs, optional: true

--- a/modules/nf-core/hifiasm/main.nf
+++ b/modules/nf-core/hifiasm/main.nf
@@ -2,7 +2,7 @@ process HIFIASM {
     tag "$meta.id"
     label 'process_high'
 
-    conda "bioconda::hifiasm=0.19.8"
+    conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/hifiasm:0.19.8--h43eeafb_0' :
         'biocontainers/hifiasm:0.19.8--h43eeafb_0' }"

--- a/modules/nf-core/hifiasm/main.nf
+++ b/modules/nf-core/hifiasm/main.nf
@@ -2,10 +2,10 @@ process HIFIASM {
     tag "$meta.id"
     label 'process_high'
 
-    conda "bioconda::hifiasm=0.18.5"
+    conda "bioconda::hifiasm=0.19.8"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/hifiasm:0.18.5--h5b5514e_0' :
-        'biocontainers/hifiasm:0.18.5--h5b5514e_0' }"
+        'https://depot.galaxyproject.org/singularity/hifiasm:0.19.8--h43eeafb_0' :
+        'biocontainers/hifiasm:0.19.8--h43eeafb_0' }"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/hifiasm/meta.yml
+++ b/modules/nf-core/hifiasm/meta.yml
@@ -15,7 +15,6 @@ tools:
       tool_dev_url: https://github.com/chhylp123/hifiasm
       doi: "10.1038/s41592-020-01056-5"
       licence: ["MIT"]
-
 input:
   - meta:
       type: map
@@ -33,7 +32,7 @@ input:
       type: file
       description: Yak kmer dump file for maternal reads (can be used for haplotype resolution). It can have an arbitrary extension.
   - use_parental_kmers:
-      type: logical
+      type: boolean
       description: A flag (true or false) signalling if the module should use the paternal and maternal kmer dumps.
   - hic_read1:
       type: file
@@ -41,7 +40,6 @@ input:
   - hic_read2:
       type: file
       description: Hi-C data Reverse reads.
-
 output:
   - meta:
       type: map
@@ -88,7 +86,9 @@ output:
       type: file
       description: Reverse overlaps
       pattern: "*.ovlp.reverse.bin"
-
 authors:
+  - "@sidorov-si"
+  - "@scorreard"
+maintainers:
   - "@sidorov-si"
   - "@scorreard"

--- a/modules/nf-core/mitohifi/findmitoreference/environment.yml
+++ b/modules/nf-core/mitohifi/findmitoreference/environment.yml
@@ -1,0 +1,5 @@
+name: mitohifi_findmitoreference
+channels:
+  - conda-forge
+  - bioconda
+  - defaults

--- a/modules/nf-core/mitohifi/findmitoreference/main.nf
+++ b/modules/nf-core/mitohifi/findmitoreference/main.nf
@@ -1,16 +1,12 @@
 process MITOHIFI_FINDMITOREFERENCE {
-    tag '$species'
+    tag "$species"
     label 'process_low'
 
-    // Docker image available at the biocontainers Dockerhub
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://biocontainers/mitohifi:3.0.0_cv1':
-        'docker.io/biocontainers/mitohifi:3.0.0_cv1' }"
+    // Docker image available at the project github repository
+    container 'ghcr.io/marcelauliano/mitohifi:master'
 
     input:
     val species
-    val email
-    val min_length
 
     output:
     path "*.fasta",                 emit: fasta
@@ -21,16 +17,16 @@ process MITOHIFI_FINDMITOREFERENCE {
     task.ext.when == null || task.ext.when
 
     script:
+    def args = task.ext.args ?: ''
     """
     findMitoReference.py \\
-        --species $species \\
-        --email $email \\
-        --min_length $min_length \\
-        --outfolder .
+        --species "$species" \\
+        --outfolder . \\
+        $args
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        mitohifi: \$( mitohifi.py --version 2>&1 | head -n1 | sed 's/^.*MitoHiFi //; s/ .*\$//' )
+        mitohifi: \$( mitohifi.py -v | sed 's/.* //' )
     END_VERSIONS
     """
 
@@ -41,7 +37,7 @@ process MITOHIFI_FINDMITOREFERENCE {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        mitohifi: \$( mitohifi.py --version 2>&1 | head -n1 | sed 's/^.*MitoHiFi //; s/ .*\$//' )
+        mitohifi: \$( mitohifi.py -v | sed 's/.* //' )
     END_VERSIONS
     """
 }

--- a/modules/nf-core/mitohifi/findmitoreference/main.nf
+++ b/modules/nf-core/mitohifi/findmitoreference/main.nf
@@ -6,12 +6,12 @@ process MITOHIFI_FINDMITOREFERENCE {
     container 'ghcr.io/marcelauliano/mitohifi:master'
 
     input:
-    val species
+    tuple val(meta), val(species)
 
     output:
-    path "*.fasta",                 emit: fasta
-    path "*.gb",                    emit: gb
-    path "versions.yml",            emit: versions
+    tuple val(meta), path("*.fasta"), emit: fasta
+    tuple val(meta), path("*.gb")   , emit: gb
+    path "versions.yml"             , emit: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/mitohifi/findmitoreference/meta.yml
+++ b/modules/nf-core/mitohifi/findmitoreference/meta.yml
@@ -12,20 +12,11 @@ tools:
       tool_dev_url: https://github.com/marcelauliano/MitoHiFi
       doi: "10.1101/2022.12.23.521667"
       licence: ["MIT"]
-
 input:
   - species:
       type: string
       description: Latin name of the species for which a mitochondrial genome should be fetched
       pattern: "[A-Z]?[a-z]* [a-z]*"
-  - email:
-      type: string
-      description: Email address for NCBI query
-  - min_length:
-      type: integer
-      description: Minimum length of the mitochondrial genome
-      pattern: "[0-9]*"
-
 output:
   - versions:
       type: file
@@ -39,6 +30,7 @@ output:
       type: file
       description: Downloaded mitochondrial genome in Genbank format
       pattern: "*.gb"
-
 authors:
+  - "@verku"
+maintainers:
   - "@verku"

--- a/modules/nf-core/mitohifi/mitohifi/main.nf
+++ b/modules/nf-core/mitohifi/mitohifi/main.nf
@@ -14,7 +14,7 @@ process MITOHIFI_MITOHIFI {
     val mito_code
 
     output:
-    tuple val(meta), path("*fasta")                          , emit: fasta
+    tuple val(meta), path("*mitogenome.fasta")               , emit: fasta
     tuple val(meta), path("*contigs_stats.tsv")              , emit: stats
     tuple val(meta), path("*gb")                             , emit: gb, optional: true
     tuple val(meta), path("*gff")                            , emit: gff, optional: true
@@ -40,17 +40,25 @@ process MITOHIFI_MITOHIFI {
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
         error "MitoHiFi module does not support Conda. Please use Docker / Singularity instead."
     }
-
-    def args = task.ext.args ?: ''
     if (! ["c", "r"].contains(input_mode)) {
         error "r for reads or c for contigs must be specified"
     }
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: meta.id
+    def zipped = input.name.endsWith('.gz')
+    // Mitohifi deletes the original file when renaming headers.
+    def fasta = ( zipped ? input.name - '.gz' : input )
     """
-    mitohifi.py -${input_mode} ${input} \\
+    ${zipped ? "gzip -dc $input >" : "cp ${input}"} ${fasta}
+    mitohifi.py -${input_mode} ${fasta} \\
         -f ${ref_fa} \\
         -g ${ref_gb} \\
         -o ${mito_code} \\
         -t $task.cpus ${args}
+    
+    # Rename files to include prefix
+    find . -maxdepth 1 -type f ! -name '.*' -exec sh -c 'for f do mv "\$f" "${prefix}.\${f#./}"; done' sh {} +
+
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         mitohifi: \$( mitohifi.py --version 2>&1 | head -n1 | sed 's/^.*MitoHiFi //; s/ .*\$//' )
@@ -58,10 +66,11 @@ process MITOHIFI_MITOHIFI {
     """
 
     stub:
+    def prefix = task.ext.prefix ?: meta.id
     """
-    touch final_mitogenome.fasta
-    touch final_mitogenome.fasta
-    touch contigs_stats.tsv
+    touch ${prefix}.final_mitogenome.fasta
+    touch ${prefix}.final_mitogenome.fasta
+    touch ${prefix}.contigs_stats.tsv
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/mitohifi/mitohifi/meta.yml
+++ b/modules/nf-core/mitohifi/mitohifi/meta.yml
@@ -12,16 +12,11 @@ tools:
       tool_dev_url: https://github.com/marcelauliano/MitoHiFi
       doi: "10.1101/2022.12.23.521667"
       licence: ["MIT"]
-
 input:
-  - reads:
+  - input:
       type: file
-      description: Path to PacBio HiFi reads
+      description: Path to PacBio HiFi reads or contigs. Type (-r/-c) is specified in ext.args2
       pattern: "*.{fa,fa.gz,fasta,fasta.gz}"
-  - contigs:
-      type: file
-      description: Path to genome assembly
-      pattern: "*.{fa,fasta}"
   - ref_fa:
       type: file
       description: Reference sequence
@@ -30,11 +25,14 @@ input:
       type: file
       description: Reference annotation
       pattern: "*.{gb}"
+  - input_mode:
+      type: string
+      description: Specifies type of input - reads or contigs
+      pattern: "{r,c}"
   - code:
       type: integer
       description: Mitochndrial code for annotation
       pattern: "[0-9]*"
-
 output:
   - versions:
       type: file
@@ -104,6 +102,7 @@ output:
       type: file
       description: Software versions used in the run
       pattern: "versions.yml"
-
 authors:
+  - "@ksenia-krasheninnikova"
+maintainers:
   - "@ksenia-krasheninnikova"

--- a/modules/nf-core/mitohifi/mitohifi/mitohifi-mitohifi.diff
+++ b/modules/nf-core/mitohifi/mitohifi/mitohifi-mitohifi.diff
@@ -1,0 +1,58 @@
+Changes in module 'nf-core/mitohifi/mitohifi'
+--- modules/nf-core/mitohifi/mitohifi/main.nf
++++ modules/nf-core/mitohifi/mitohifi/main.nf
+@@ -14,7 +14,7 @@
+     val mito_code
+ 
+     output:
+-    tuple val(meta), path("*fasta")                          , emit: fasta
++    tuple val(meta), path("*mitogenome.fasta")               , emit: fasta
+     tuple val(meta), path("*contigs_stats.tsv")              , emit: stats
+     tuple val(meta), path("*gb")                             , emit: gb, optional: true
+     tuple val(meta), path("*gff")                            , emit: gff, optional: true
+@@ -40,17 +40,25 @@
+     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+         error "MitoHiFi module does not support Conda. Please use Docker / Singularity instead."
+     }
+-
+-    def args = task.ext.args ?: ''
+     if (! ["c", "r"].contains(input_mode)) {
+         error "r for reads or c for contigs must be specified"
+     }
++    def args = task.ext.args ?: ''
++    def prefix = task.ext.prefix ?: meta.id
++    def zipped = input.name.endsWith('.gz')
++    // Mitohifi deletes the original file when renaming headers.
++    def fasta = ( zipped ? input.name - '.gz' : input )
+     """
+-    mitohifi.py -${input_mode} ${input} \\
++    ${zipped ? "gzip -dc $input >" : "cp ${input}"} ${fasta}
++    mitohifi.py -${input_mode} ${fasta} \\
+         -f ${ref_fa} \\
+         -g ${ref_gb} \\
+         -o ${mito_code} \\
+         -t $task.cpus ${args}
++    
++    # Rename files to include prefix
++    find . -maxdepth 1 -type f ! -name '.*' -exec sh -c 'for f do mv "\$f" "${prefix}.\${f#./}"; done' sh {} +
++
+     cat <<-END_VERSIONS > versions.yml
+     "${task.process}":
+         mitohifi: \$( mitohifi.py --version 2>&1 | head -n1 | sed 's/^.*MitoHiFi //; s/ .*\$//' )
+@@ -58,10 +66,11 @@
+     """
+ 
+     stub:
++    def prefix = task.ext.prefix ?: meta.id
+     """
+-    touch final_mitogenome.fasta
+-    touch final_mitogenome.fasta
+-    touch contigs_stats.tsv
++    touch ${prefix}.final_mitogenome.fasta
++    touch ${prefix}.final_mitogenome.fasta
++    touch ${prefix}.contigs_stats.tsv
+ 
+     cat <<-END_VERSIONS > versions.yml
+     "${task.process}":
+
+************************************************************

--- a/nextflow.config
+++ b/nextflow.config
@@ -27,6 +27,7 @@ params {
     // 'symlink' : Use for test data.
     // 'copy'    : Use for full analysis data.
     publish_mode       = 'copy' // values: 'symlink', 'copy'
+    use_phased         = false
 
     // Tool specific
     // fastk.kmer_size = 31

--- a/nextflow.config
+++ b/nextflow.config
@@ -48,7 +48,7 @@ params {
     // MASH
     mash.screen_db     = 'https://gembox.cbcb.umd.edu/mash/refseq.genomes%2Bplasmid.k21s1000.msh'
     // MITOHIFI
-    mitohifi.code      = 0
+    mitohifi.code      = 1 // Standard genetic code
 
     // General module configuration
     multiqc.config = "$baseDir/configs/multiqc_conf.yaml"

--- a/nextflow.config
+++ b/nextflow.config
@@ -33,7 +33,7 @@ params {
     // genescopefk.kmer_size = 31
     // BUSCO
     // busco.lineages = 'auto'
-    busco.lineage_path = null
+    busco.lineages_db_path = null
     // DIAMOND
     diamond.db         = null
     // BLAST

--- a/nextflow.config
+++ b/nextflow.config
@@ -30,8 +30,12 @@ params {
     use_phased         = false
 
     // Tool specific
-    // fastk.kmer_size = 31
-    // genescopefk.kmer_size = 31
+    // FASTK
+    fastk.kmer_size = 31
+    // GENESCOPEFK
+    genescopefk.kmer_size = 31
+    // HIFIASM
+    hifiasm = [ '' ]
     // BUSCO
     // busco.lineages = 'auto'
     busco.lineages_db_path = null

--- a/nextflow.config
+++ b/nextflow.config
@@ -43,6 +43,8 @@ params {
     ncbi.taxonomy      = null
     // MASH
     mash.screen_db     = 'https://gembox.cbcb.umd.edu/mash/refseq.genomes%2Bplasmid.k21s1000.msh'
+    // MITOHIFI
+    mitohifi.code      = 0
 
     // General module configuration
     multiqc.config = "$baseDir/configs/multiqc_conf.yaml"

--- a/nextflow.config
+++ b/nextflow.config
@@ -29,6 +29,11 @@ params {
     publish_mode       = 'copy' // values: 'symlink', 'copy'
 
     // Tool specific
+    // settings {
+    //     fastk.kmer_size = 31
+    //     genescopefk.kmer_size = 31
+    //     // busco.lineages = 'auto'
+    // }
     // BUSCO
     busco_lineage_path = null
     // DIAMOND

--- a/nextflow.config
+++ b/nextflow.config
@@ -29,24 +29,22 @@ params {
     publish_mode       = 'copy' // values: 'symlink', 'copy'
 
     // Tool specific
-    // settings {
-    //     fastk.kmer_size = 31
-    //     genescopefk.kmer_size = 31
-    //     // busco.lineages = 'auto'
-    // }
+    // fastk.kmer_size = 31
+    // genescopefk.kmer_size = 31
     // BUSCO
-    busco_lineage_path = null
+    // busco.lineages = 'auto'
+    busco.lineage_path = null
     // DIAMOND
-    diamond_db         = null
+    diamond.db         = null
     // BLAST
-    blast_db           = null
+    blast.db           = null
     // BLOBTOOLS
-    ncbi_taxonomy      = null
+    ncbi.taxonomy      = null
     // MASH
-    mash_screen_db     = 'https://gembox.cbcb.umd.edu/mash/refseq.genomes%2Bplasmid.k21s1000.msh'
+    mash.screen_db     = 'https://gembox.cbcb.umd.edu/mash/refseq.genomes%2Bplasmid.k21s1000.msh'
 
     // General module configuration
-    multiqc_config = "$baseDir/configs/multiqc_conf.yaml"
+    multiqc.config = "$baseDir/configs/multiqc_conf.yaml"
 
 }
 

--- a/subworkflows/local/assemble_hifi/main.nf
+++ b/subworkflows/local/assemble_hifi/main.nf
@@ -15,7 +15,7 @@ workflow ASSEMBLE_HIFI {
                 [ meta + [ assembly: [ assembler: 'hifiasm', stage: 'raw', id: uuid, build: "hifiasm-raw-$uuid" ] ], reads ] 
             }
         HIFIASM(
-            hifi_reads,
+            reads_ch,
             [], // paternal k-mers
             [], // maternal k-mers
             [], // Hi-C r1

--- a/subworkflows/local/assemble_hifi/main.nf
+++ b/subworkflows/local/assemble_hifi/main.nf
@@ -1,0 +1,68 @@
+include { HIFIASM         } from "$projectDir/modules/nf-core/hifiasm/main"
+include { GFATOOLS_GFA2FA } from "$projectDir/modules/local/gfatools/gfa2fa"
+include { GFASTATS        } from "$projectDir/modules/nf-core/gfastats/main"
+
+workflow ASSEMBLE_HIFI {
+    take:
+    hifi_reads
+
+    main:
+        // Need to include a build ID here. 
+        HIFIASM(
+            hifi_reads.flatMap { meta, reads -> params.hifiasm ? params.hifiasm.collect { [ meta, reads ] } : [ [ meta, reads ] ] },
+            [], // paternal k-mers
+            [], // maternal k-mers
+            [], // Hi-C r1
+            []  // Hi-C r2
+        )
+        raw_assembly_ch = params.use_phased ? HIFIASM.out.paternal_contigs.mix( HIFIASM.out.maternal_contigs ) : HIFIASM.out.processed_contigs
+        GFASTATS(
+            raw_assembly_ch,
+            "gfa",   // output format
+            "",      // genome size
+            "",      // target
+            [],      // AGP file
+            [],      // include bed
+            [],      // exclude bed
+            []       // SAK instructions
+        )
+        GFATOOLS_GFA2FA( raw_assembly_ch )
+
+        gfa_ch = params.use_phased ? 
+            HIFIASM.out.paternal_contigs
+                .join( HIFIASM.out.maternal_contigs )
+                .map { meta, pgfa, mgfa -> [ meta, [ pgfa, mgfa ] ] } : 
+            HIFIASM.out.processed_contigs
+        assemblies_ch = GFATOOLS_GFA2FA.out.fasta.groupTuple( sort: { it.name } )
+            .join( gfa_ch )
+            .map { meta, fasta, gfa -> 
+                [ meta, 
+                    params.use_phased ? 
+                    [ 
+                        id: 'hifiasm_phased', 
+                        pri_fasta: fasta[0],
+                        alt_fasta: fasta[1],
+                        pri_gfa: gfa[0],
+                        alt_gfa: gfa[1]
+                    ] :
+                    [
+                        id: 'hifiasm_consensus', 
+                        pri_fasta: fasta[0],
+                        alt_fasta: null,
+                        pri_gfa: gfa,
+                        alt_gfa: null
+                    ]
+                ]
+            }
+            .dump( tag: "Assemblies: Pre-purge", pretty: true )
+
+        // Find mitochondria
+            // Need to check options to mitohifi modules.
+
+    versions_ch =
+
+    emit:
+    assemblies = assemblies_ch
+    versions = versions_ch
+
+}

--- a/subworkflows/local/assemble_hifi/main.nf
+++ b/subworkflows/local/assemble_hifi/main.nf
@@ -56,9 +56,6 @@ workflow ASSEMBLE_HIFI {
             }
             .dump( tag: "Assemblies: Pre-purge", pretty: true )
 
-        // Find mitochondria
-            // Need to check options to mitohifi modules.
-
     versions_ch = HIFIASM.out.versions.first()
         .mix( GFASTATS.out.versions.first() )
         .mix( GFATOOLS_GFA2FA.out.versions.first() )

--- a/subworkflows/local/assemble_hifi/main.nf
+++ b/subworkflows/local/assemble_hifi/main.nf
@@ -59,7 +59,9 @@ workflow ASSEMBLE_HIFI {
         // Find mitochondria
             // Need to check options to mitohifi modules.
 
-    versions_ch =
+    versions_ch = HIFIASM.out.versions.first()
+        .mix( GFASTATS.out.versions.first() )
+        .mix( GFATOOLS_GFA2FA.out.versions.first() )
 
     emit:
     assemblies = assemblies_ch

--- a/subworkflows/local/evaluate_assembly/main.nf
+++ b/subworkflows/local/evaluate_assembly/main.nf
@@ -45,6 +45,7 @@ workflow EVALUATE_ASSEMBLY {
                 // If GOAT is disabled, auto-detect.
                 [ [ meta, asm, 'auto' ] ]
             }
+        }
         .dump(tag: 'BUSCO')
         .multiMap { meta, asm, line ->
             assembly_ch: [ meta, asm ]

--- a/subworkflows/local/evaluate_assembly/main.nf
+++ b/subworkflows/local/evaluate_assembly/main.nf
@@ -16,24 +16,12 @@ workflow EVALUATE_ASSEMBLY {
     // Kmer consistency check
     MERQURYFK_MERQURYFK (
         fastk_db.combine( assembly_ch.map { sample, assembly ->
-            [
-                sample, 
-                ( assembly.alt_fasta ? [ assembly.pri_fasta, assembly.alt_fasta ] : assembly.pri_fasta ),
-                assembly.id
-            ] 
-        }, by: 0 ).map {
-            sample, fastk_hist, fastk_ktab, asm_files, build_name -> 
-                [ 
-                    sample + [ build: build_name ],
-                    fastk_hist,
-                    fastk_ktab,
-                    asm_files
-                ]
-        }
+                [ sample, ( assembly.alt_fasta ? [ assembly.pri_fasta, assembly.alt_fasta ] : assembly.pri_fasta ) ] 
+            }, by: 0 )
     )
 
     // Evaluate core gene space coverage
-    busco_input = assembly_ch.map { sample, assembly -> [ sample + [ build: assembly.id ] , assembly.pri_fasta ] }
+    busco_input = assembly_ch.map { sample, assembly -> [ sample, assembly.pri_fasta ] }
         .flatMap { meta, asm -> 
             if ( params.busco.lineages ) {
                 // User supplied list takes priority.

--- a/subworkflows/local/genome_properties/main.nf
+++ b/subworkflows/local/genome_properties/main.nf
@@ -24,15 +24,16 @@ workflow GENOME_PROPERTIES {
     GENESCOPEFK.out.summary
         .view { meta, summary ->
             def genome_size_estimates = summary.readLines().find { it.startsWith("Genome Haploid Length") } =~ /[0-9,]+/
+            def nf = java.text.NumberFormat.getInstance(Locale.US)
             if ( genome_size_estimates.size() == 1 ) {
-                if ( meta.sample.genome_size < 0.9 * genome_size_estimates[0] ||
-                    meta.sample.genome_size > 1.1 * genome_size_estimates[0] ) {
+                if ( meta.sample.genome_size < 0.9 * nf.parse(genome_size_estimates[0]).intValue() ||
+                    meta.sample.genome_size > 1.1 * nf.parse(genome_size_estimates[0]).intValue() ) {
                         log.warn "GeneScopeFK genome size estimate differs from GOAT estimate"
                 }
             } else {
                 // Min and Max estimate
-                if ( meta.sample.genome_size < genome_size_estimates[0] ||
-                    meta.sample.genome_size > genome_size_estimates[1] ) {
+                if ( meta.sample.genome_size < nf.parse(genome_size_estimates[0]).intValue() ||
+                    meta.sample.genome_size > nf.parse(genome_size_estimates[1]).intValue() ) {
                         log.warn "GeneScopeFK genome size estimate differs from GOAT estimate"
                 }
             }

--- a/subworkflows/local/genome_properties/main.nf
+++ b/subworkflows/local/genome_properties/main.nf
@@ -26,14 +26,14 @@ workflow GENOME_PROPERTIES {
             def genome_size_estimates = summary.readLines().find { it.startsWith("Genome Haploid Length") } =~ /[0-9,]+/
             def nf = java.text.NumberFormat.getInstance(Locale.US)
             if ( genome_size_estimates.size() == 1 ) {
-                if ( meta.sample.genome_size < 0.9 * nf.parse(genome_size_estimates[0]).intValue() ||
-                    meta.sample.genome_size > 1.1 * nf.parse(genome_size_estimates[0]).intValue() ) {
+                if ( nf.parse(meta.sample.genome_size).intValue() < 0.9 * nf.parse(genome_size_estimates[0]).intValue() ||
+                    nf.parse(meta.sample.genome_size).intValue() > 1.1 * nf.parse(genome_size_estimates[0]).intValue() ) {
                         log.warn "GeneScopeFK genome size estimate differs from GOAT estimate"
                 }
             } else {
                 // Min and Max estimate
-                if ( meta.sample.genome_size < nf.parse(genome_size_estimates[0]).intValue() ||
-                    meta.sample.genome_size > nf.parse(genome_size_estimates[1]).intValue() ) {
+                if ( nf.parse(meta.sample.genome_size).intValue() < nf.parse(genome_size_estimates[0]).intValue() ||
+                    nf.parse(meta.sample.genome_size).intValue() > nf.parse(genome_size_estimates[1]).intValue() ) {
                         log.warn "GeneScopeFK genome size estimate differs from GOAT estimate"
                 }
             }

--- a/subworkflows/local/genome_properties/main.nf
+++ b/subworkflows/local/genome_properties/main.nf
@@ -22,8 +22,8 @@ workflow GENOME_PROPERTIES {
 
     // Print warning if genome size estimate is outside predicted range.
     GENESCOPEFK.out.summary
-        .view { meta, summary ->             
-            def genome_size_estimates = it.readLines().find { it.startsWith("Genome Haploid Length") } =~ /[0-9,]+/
+        .view { meta, summary ->
+            def genome_size_estimates = summary.readLines().find { it.startsWith("Genome Haploid Length") } =~ /[0-9,]+/
             if ( genome_size_estimates.size() == 1 ) {
                 if ( meta.sample.genome_size < 0.9 * genome_size_estimates[0] ||
                     meta.sample.genome_size > 1.1 * genome_size_estimates[0] ) {

--- a/subworkflows/local/genome_properties/main.nf
+++ b/subworkflows/local/genome_properties/main.nf
@@ -22,7 +22,7 @@ workflow GENOME_PROPERTIES {
 
     // Print warning if genome size estimate is outside predicted range.
     GENESCOPEFK.out.summary
-        .view { meta, summary ->
+        .subscribe { meta, summary ->
             def genome_size_estimates = summary.readLines().find { it.startsWith("Genome Haploid Length") } =~ /[0-9,]+/
             def nf = java.text.NumberFormat.getInstance(Locale.US)
             if ( genome_size_estimates.size() == 1 ) {

--- a/subworkflows/local/prepare_input/main.nf
+++ b/subworkflows/local/prepare_input/main.nf
@@ -9,7 +9,6 @@ include { GOAT_TAXONSEARCH } from "$projectDir/modules/nf-core/goat/taxonsearch/
 ```yaml
 sample:
   name: Species name
-  ploidy: 2
 assembly:
   - id: assemblerX_build1
     pri_fasta: /path/to/primary_asm.fasta
@@ -28,23 +27,12 @@ rnaseq:
   - reads: /path/to/reads
 isoseq:
   - reads: /path/to/reads
-settings:
-  busco:
-    lineages:
-  fastk:
-    kmer_size:
-  genescopefk:
-    kmer_size:
-  hifiasm:
-    - Opts 1
-    - Opts 2
 ```
 leads to the following YAML data structure
 ```
 [
     sample:[
         name: Species name
-        ploidy: 2
     ],
     assembly:[
         [
@@ -85,8 +73,9 @@ Output meta map structure:
     single_end: true,   // Needed for nf-core modules functionality
     sample: [
         name: "Species name",
-        ploidy: 2,
-        chr_count: 13
+        genome_size: 1234,     // GOAT
+        ploidy: 2,             // GOAT
+        chr_count: 13          // GOAT
     ],
     reads_hifi: [
         single_end: true,
@@ -97,18 +86,8 @@ Output meta map structure:
         kmer_cov: 50
     ]
     settings: [
-        genescopefk: [
-            kmer_size: 31
-        ],
-        fastk: [
-            kmer_size: 31
-        ],
         busco: [
-            lineages: auto
-        ],
-        hifiasm: [
-            "Opts set 1",
-            "Opts set 2"
+            lineages: auto     // GOAT
         ]
     ]
 ]

--- a/subworkflows/local/purge_dups/main.nf
+++ b/subworkflows/local/purge_dups/main.nf
@@ -69,6 +69,7 @@ workflow PURGE_DUPLICATES {
     reads_plus_assembly_ch
         .filter { meta, reads, assembly -> assembly.alt_fasta != null }
         .map { meta, reads, assembly -> [ meta + [ build: assembly.id ], assembly.alt_fasta ] }
+        // Purges haplotigs only when using consensus
         .mix( PURGEDUPS_GETSEQS_PRIMARY.out.haplotigs )
         .groupTuple()
         .set { alternate_assembly_ch }


### PR DESCRIPTION
- Add Genome size, chromosome number, and ploidy via GOAT
- Add warning if genome size differs largely from genescopefk estimate
- Update hifiasm module to output `*.bp.p_ctg.gfa`
- Update parameter "schema" to not break reentrancy, and rename certain variables.
- Include parameter to switch between using haplotypes or consensus output.
- Include mitohifi ( Resolves #29; Resolves #35 )
- Update hifiasm tool version.
- Increase nf-core time defaults.
- Rename output folders.
- Restructure workflow meta data.