### PR TITLE
Refactor workflow

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -96,6 +96,7 @@ workflow {
     } else {
         // Nothing more than evaluate
     }
+    ch_raw_assemblies.dump(tag: 'Assemblies: Raw')
     // TODO: Add organelle assembly from reads
     ASSEMBLE_ORGANELLES ( raw_assemblies )
     // TODO: filter organelles from assemblies
@@ -112,7 +113,7 @@ workflow {
     ch_to_screen = setAssemblyStage (
         ch_raw_assemblies,
         'decontaminated' // Set assembly stage now for filenaming
-    )
+    ).dump(tag: 'Assemblies: to screen')
     if ( 'screen' in workflow_steps ) {
         DECONTAMINATE( ch_to_screen )
         ch_cleaned_assemblies = DECONTAMINATE.out.assemblies
@@ -121,13 +122,13 @@ workflow {
     }
     ch_cleaned_assemblies = ch_cleaned_assemblies.mix (
         preassembledInput( PREPARE_INPUT.out.assemblies, 'decontaminated' )
-    )
+    ).dump(tag: 'Assemblies: Cleaned')
 
     // Purge duplicates
     ch_to_purge = setAssemblyStage (
         ch_cleaned_assemblies,
         'purged' // Set assembly stage now for filenaming
-    )
+    ).dump(tag: 'Assemblies: to purge')
     if ( 'purge' in workflow_steps ) {
         PURGE_DUPLICATES (
             ch_to_purge,
@@ -139,7 +140,7 @@ workflow {
     }
     ch_purged_assemblies = ch_purged_assemblies.mix(
         preassembledInput( PREPARE_INPUT.out.assemblies, 'purged' )
-    )
+    ).dump(tag: 'Assemblies: Purged')
     EVALUATE_PURGED_ASSEMBLY (
         ch_purged_assemblies,
         PREPARE_INPUT.out.hifi,
@@ -150,7 +151,7 @@ workflow {
     ch_to_polish = setAssemblyStage (
         ch_purged_assemblies,
         'polished' // Set assembly stage now for filenaming
-    )
+    ).dump(tag: 'Assemblies: to polish')
     if ( 'polish' in workflow_steps ) {
         // Run polishers
         ch_polished_assemblies = ch_to_polish
@@ -159,13 +160,13 @@ workflow {
     }
     ch_polished_assemblies = ch_polished_assemblies.mix(
         preassembledInput( PREPARE_INPUT.out.assemblies, 'polished' )
-    )
+    ).dump(tag: 'Assemblies: Polished')
 
     // Scaffold
     ch_to_scaffold = setAssemblyStage (
         ch_polished_assemblies,
         'scaffolded' // Set assembly stage now for filenaming
-    )
+    ).dump(tag: 'Assemblies: to scaffold')
     if ( 'scaffold' in workflow_steps ) {
         // Run scaffolder
         ch_scaffolded_assemblies = ch_to_scaffold
@@ -174,13 +175,13 @@ workflow {
     }
     ch_scaffolded_assemblies = ch_scaffolded_assemblies.mix(
         preassembledInput( PREPARE_INPUT.out.assemblies, 'scaffolded' )
-    )
+    ).dump(tag: 'Assemblies: Scaffolded')
 
     // Curate
     ch_to_curate = setAssemblyStage (
         ch_scaffolded_assemblies,
         'curated' // Set assembly stage now for filenaming
-    )
+    ).dump(tag: 'Assemblies: to curate')
     if ( 'curate' in workflow_steps ) {
         // Run assemblers
         ch_curated_assemblies = ch_to_curate
@@ -189,7 +190,7 @@ workflow {
     }
     ch_curated_assemblies = ch_curated_assemblies.mix(
         preassembledInput( PREPARE_INPUT.out.assemblies, 'curated' )
-    )
+    ).dump(tag: 'Assemblies: Curated')
 
     // Align RNAseq
     if( 'alignRNA' in workflow_steps ) {

--- a/main.nf
+++ b/main.nf
@@ -75,8 +75,8 @@ workflow {
         // QC Steps
         INSPECT_DATA(
             PREPARE_INPUT.out.hifi,
-            BUILD_HIFI_DATABASES.out.fastk_histogram.join( BUILD_HIFI_DATABASES.out.fastk_ktab ),
-            BUILD_HIC_DATABASES.out.fastk_histogram.join( BUILD_HIC_DATABASES.out.fastk_ktab )
+            BUILD_HIFI_DATABASES.out.fastk_hist_ktab,
+            BUILD_HIC_DATABASES.out.fastk_hist_ktab
         )
     }
 
@@ -105,7 +105,7 @@ workflow {
     EVALUATE_RAW_ASSEMBLY (
         ch_raw_assemblies,
         PREPARE_INPUT.out.hifi,
-        BUILD_HIFI_DATABASES.out.fastk_histogram.join( BUILD_HIFI_DATABASES.out.fastk_ktab ),
+        BUILD_HIFI_DATABASES.out.fastk_hist_ktab,
     )
 
     // Contamination screen
@@ -143,7 +143,7 @@ workflow {
     EVALUATE_PURGED_ASSEMBLY (
         ch_purged_assemblies,
         PREPARE_INPUT.out.hifi,
-        BUILD_HIFI_DATABASES.out.fastk_histogram.join( BUILD_HIFI_DATABASES.out.fastk_ktab )
+        BUILD_HIFI_DATABASES.out.fastk_hist_ktab
     )
 
     // Polish

--- a/main.nf
+++ b/main.nf
@@ -10,24 +10,17 @@ include { PREPARE_INPUT } from "$projectDir/subworkflows/local/prepare_input/mai
 include { BUILD_DATABASES as BUILD_HIFI_DATABASES } from "$projectDir/subworkflows/local/build_databases/main"
 include { BUILD_DATABASES as BUILD_HIC_DATABASES  } from "$projectDir/subworkflows/local/build_databases/main"
 
-include { GENOME_PROPERTIES } from "$projectDir/subworkflows/local/genome_properties/main"
-include { COMPARE_LIBRARIES } from "$projectDir/subworkflows/local/compare_libraries/main"
-include { SCREEN_READS      } from "$projectDir/subworkflows/local/screen_read_contamination/main"
+include { INSPECT_DATA } from "$projectDir/subworkflows/local/inspect_data/main"
 
-include { ASSEMBLE_HIFI } from "$projectDir/subworkflows/local/assemble_hifi/main"
+include { ASSEMBLE                                   } from "$projectDir/subworkflows/local/assemble/main"
+include { ASSEMBLE_ORGANELLES                        } from "$projectDir/subworkflows/local/assemble_organelles/main"
+include { COMPARE_ASSEMBLIES                         } from "$projectDir/subworkflows/local/compare_assemblies/main"
+include { EVALUATE_ASSEMBLY as EVALUATE_RAW_ASSEMBLY } from "$projectDir/subworkflows/local/evaluate_assembly/main"
 
-include { FCSGX_FETCHDB } from "$projectDir/modules/local/fcsgx/fetchdb"
-include { FCSGX_RUNGX   } from "$projectDir/modules/local/fcsgx/rungx"
-include { FCSGX_CLEAN   } from "$projectDir/modules/local/fcsgx/clean"
+include { DECONTAMINATE } from "$projectDir/modules/local/decontaminate/main"
 
 include { PURGE_DUPLICATES } from "$projectDir/subworkflows/local/purge_dups/main"
 
-include { MITOHIFI_FINDMITOREFERENCE } from "$projectDir/modules/nf-core/mitohifi/findmitoreference/main"
-include { MITOHIFI_MITOHIFI          } from "$projectDir/modules/nf-core/mitohifi/mitohifi/main"
-
-include { COMPARE_ASSEMBLIES } from "$projectDir/subworkflows/local/compare_assemblies/main"
-
-include { EVALUATE_ASSEMBLY as EVALUATE_RAW_ASSEMBLY    } from "$projectDir/subworkflows/local/evaluate_assembly/main"
 include { EVALUATE_ASSEMBLY as EVALUATE_PURGED_ASSEMBLY } from "$projectDir/subworkflows/local/evaluate_assembly/main"
 
 include { ALIGN_RNASEQ       } from "$projectDir/subworkflows/local/align_rnaseq/main"
@@ -78,17 +71,10 @@ workflow {
     // Data inspection
     if ( 'inspect' in workflow_steps ) {
         // QC Steps
-        GENOME_PROPERTIES (
-            BUILD_HIFI_DATABASES.out.fastk_histogram.join( BUILD_HIFI_DATABASES.out.fastk_ktab )
-        )
-        COMPARE_LIBRARIES (
-            BUILD_HIFI_DATABASES.out.fastk_histogram.join( BUILD_HIFI_DATABASES.out.fastk_ktab ).join(
-            BUILD_HIC_DATABASES.out.fastk_histogram.join( BUILD_HIC_DATABASES.out.fastk_ktab ) )
-        )
-        SCREEN_READS (
+        INSPECT_DATA(
             PREPARE_INPUT.out.hifi,
-            // TODO:: Allow custom database ala nf-core/genomeassembler.
-            file( params.mash.screen_db, checkIfExists: true )
+            BUILD_HIFI_DATABASES.out.fastk_histogram.join( BUILD_HIFI_DATABASES.out.fastk_ktab ),
+            BUILD_HIC_DATABASES.out.fastk_histogram.join( BUILD_HIC_DATABASES.out.fastk_ktab )
         )
     }
 
@@ -103,77 +89,36 @@ workflow {
     ch_raw_assemblies = PREPARE_INPUT.out.assemblies.filter { meta, assembly -> meta.assembly.stage in ['raw'] }
     if ( 'assemble' in workflow_steps ) {
         // Run assemblers
-
-        // TODO: Make strategy check
-        ASSEMBLE_HIFI( PREPARE_INPUT.out.hifi_merged )
-        ch_raw_assemblies = ch_raw_assemblies
-            .mix( ASSEMBLE_HIFI.out.assemblies )
-
-        // Find mitochondria
-        // TODO: Need to check options to mitohifi modules.
-        MITOHIFI_FINDMITOREFERENCE( ch_raw_assemblies.map { meta, assemblies -> [ meta, meta.sample.name ] }.unique() )
-        mitohifi_ch = ch_raw_assemblies
-            .combine(
-                MITOHIFI_FINDMITOREFERENCE.out.fasta
-                    .join(MITOHIFI_FINDMITOREFERENCE.out.gb),
-                by: 0
-            )
-            .multiMap { meta, assembly, mitofa, mitogb ->
-                input: [ meta, assembly.pri_fasta ]
-                reference: mitofa
-                genbank: mitogb
-            }
-        MITOHIFI_MITOHIFI(
-            mitohifi_ch.input,
-            mitohifi_ch.reference,
-            mitohifi_ch.genbank,
-            'c',
-            params.mitohifi.code
-        )
-
-        // Assess assemblies
-        COMPARE_ASSEMBLIES (
-            ch_raw_assemblies,
-            params.reference ? file( params.reference, checkIfExists: true ) : []
-        )
-
-        EVALUATE_RAW_ASSEMBLY (
-            ch_raw_assemblies,
-            PREPARE_INPUT.out.hifi,
-            BUILD_HIFI_DATABASES.out.fastk_histogram.join( BUILD_HIFI_DATABASES.out.fastk_ktab ),
-            params.reference ? file( params.reference, checkIfExists: true ) : [],
-            params.busco.lineages_db_path ? file( params.busco.lineages_db_path, checkIfExists: true ) : []
-        )
+        ASSEMBLE ( PREPARE_INPUT.out.hifi_merged )
+        ch_raw_assemblies = ch_raw_assemblies.mix( ASSEMBLE.out.raw_assemblies )
+    } else {
+        // Nothing more than evaluate
     }
+    ASSEMBLE_ORGANELLES ( raw_assemblies )
+    // TODO: filter organelles from assemblies
+
+    // Assess assemblies
+    COMPARE_ASSEMBLIES (
+        ch_raw_assemblies,
+        params.reference ? file( params.reference, checkIfExists: true ) : []
+    )
+    EVALUATE_RAW_ASSEMBLY (
+        ch_raw_assemblies,
+        PREPARE_INPUT.out.hifi,
+        BUILD_HIFI_DATABASES.out.fastk_histogram.join( BUILD_HIFI_DATABASES.out.fastk_ktab ),
+        params.reference ? file( params.reference, checkIfExists: true ) : [],
+        params.busco.lineages_db_path ? file( params.busco.lineages_db_path, checkIfExists: true ) : []
+    )
 
     // Contamination screen
     ch_cleaned_assemblies = PREPARE_INPUT.out.assemblies.filter { meta, assembly -> meta.assembly.stage in ['decontaminated'] }
     if ( 'screen' in workflow_steps ) {
-        FCSGX_FETCHDB ( params.fcs.database ? Channel.empty() : Channel.fromPath( params.fcs.manifest, checkIfExists: true ) )
-        ch_fcs_database = params.fcs.database ? Channel.fromPath( params.fcs.database, checkIfExists: true, type: 'dir' ) : FCSGX_FETCHDB.out.database
-        ch_to_screen = ch_raw_assemblies.flatMap { meta, assembly ->
-                def updated_meta = meta.deepMerge( [ assembly: [ stage: 'decontaminated', build: "${meta.assembly.assembler}-decontaminated-${meta.assembly.id}" ] ] )
-                assembly.alt_fasta ? [
-                    [ updated_meta + [ haplotype: 0 ], updated_meta.sample.taxid, assembly.pri_fasta ],
-                    [ updated_meta + [ haplotype: 1 ], updated_meta.sample.taxid, assembly.alt_fasta ]
-                ] : [
-                    [ updated_meta + [ haplotype: 0 ], updated_meta.sample.taxid, assembly.pri_fasta ]
-                ]
-            }
-        FCSGX_RUNGX( ch_to_screen, ch_fcs_database.collect(), params.fcs.ramdisk_path )
-        FCSGX_CLEAN(
-            ch_to_screen.join( FCSGX_RUNGX.out.fcs_gx_report, by: 0 )
-                .map { meta, taxid, asm, rpt -> [ meta, asm, rpt ] }
-        )
-        ch_cleaned_assemblies = ch_cleaned_assemblies.mix(
-            FCSGX_CLEAN.out.clean_fasta
-                .map { meta, asm -> [ meta.subMap(meta.keySet()-['haplotype']), asm ] }
-                .groupTuple( sort: { a, b -> a.name <=> b.name } )
-                .map { meta, fasta ->
-                    def asm_meta = meta.assembly.subMap(['assembler','stage','id','build'])
-                    [ meta, asm_meta + (fasta.size() == 1 ? [ pri_fasta: fasta[0] ] : [ pri_fasta: fasta[0], alt_fasta: fasta[1] ] ) ]
-                }
-        )
+        DECONTAMINATE( ch_raw_assemblies )
+        ch_cleaned_assemblies = ch_cleaned_assemblies.mix( DECONTAMINATE.out.assemblies )
+    } else {
+        // Skip decontamination. Use raw assemblies
+        // TODO. Update meta stage
+        ch_cleaned_assemblies = ch_cleaned_assemblies.mix( ch_raw_assemblies )
     }
 
     // Purge duplicates
@@ -185,13 +130,6 @@ workflow {
             keySet: ['id','sample'],
             meta: 'rhs'
         )
-        // ch_topurge = ch_cleaned_assemblies
-        //     .map { meta, assembly -> [ meta.subMap(['id','sample']), meta, assembly ] }
-        //     .combine (
-        //         PREPARE_INPUT.out.hifi
-        //             .map { meta, reads -> [ meta.subMap(['id','sample']), reads ] },
-        //         by: 0
-        //     )
         if ( 'inspect' in workflow_steps ) {
             // Add kmer coverage from GenomeScope model
             ch_topurge = combineByMetaKeys(
@@ -202,37 +140,45 @@ workflow {
             )
             .map { meta, reads, assemblies, kmer_cov -> [ meta + [ kmercov: kmer_cov ], reads, assemblies ] }
         }
-            // ch_topurge.combine( GENOME_PROPERTIES.out.kmer_cov.map{ meta, cov -> [ meta.subMap(['id','sample']), cov ] } , by: 0 )
-            //     .map { key, meta, assemblies, reads, kmer_cov -> [ meta + [ kmercov: kmer_cov ], reads, assemblies ] }
-            //     .set { ch_topurge }
-        // } else {
-        //     ch_topurge.map { key, meta, assemblies, reads -> [ meta, reads, assemblies ] }
-        //         .set { ch_topurge }
-        // }
+
         PURGE_DUPLICATES ( ch_topurge.dump( tag: 'Purge duplicates: input' ) )
         ch_purged_assemblies = ch_purged_assemblies.mix( PURGE_DUPLICATES.out.assembly )
-        EVALUATE_PURGED_ASSEMBLY (
-            ch_purged_assemblies,
-            PREPARE_INPUT.out.hifi,
-            BUILD_HIFI_DATABASES.out.fastk_histogram.join( BUILD_HIFI_DATABASES.out.fastk_ktab ),
-            params.reference ? file( params.reference, checkIfExists: true ) : [],
-            params.busco.lineages_db_path ? file( params.busco.lineages_db_path, checkIfExists: true ) : []
-        )
+
+    } else {
+        // Skip purging. Use decontaminated
+        // TODO. Update meta stage
+        ch_purged_assemblies = ch_purged_assemblies.mix( ch_cleaned_assemblies )
     }
+    EVALUATE_PURGED_ASSEMBLY (
+        ch_purged_assemblies,
+        PREPARE_INPUT.out.hifi,
+        BUILD_HIFI_DATABASES.out.fastk_histogram.join( BUILD_HIFI_DATABASES.out.fastk_ktab ),
+        params.reference ? file( params.reference, checkIfExists: true ) : [], // This makes reading it harder. Move to workflow
+        params.busco.lineages_db_path ? file( params.busco.lineages_db_path, checkIfExists: true ) : []
+    )
 
     // Polish
     if ( 'polish' in workflow_steps ) {
         // Run polishers
+    } else {
+        // Skip polishing. Use purged
+        // TODO. Update meta stage
     }
 
     // Scaffold
     if ( 'scaffold' in workflow_steps ) {
         // Run scaffolder
+    } else {
+        // Skip scaffolding. Use polished
+        // TODO. Update meta stage
     }
 
     // Curate
     if ( 'curate' in workflow_steps ) {
         // Run assemblers
+    } else {
+        // Skip curation. Use scaffolded
+        // TODO. Update meta stage
     }
 
     // Align RNAseq

--- a/main.nf
+++ b/main.nf
@@ -19,7 +19,7 @@ include { ASSEMBLE_ORGANELLES                        } from "$projectDir/subwork
 include { COMPARE_ASSEMBLIES                         } from "$projectDir/subworkflows/local/compare_assemblies/main"
 include { EVALUATE_ASSEMBLY as EVALUATE_RAW_ASSEMBLY } from "$projectDir/subworkflows/local/evaluate_assembly/main"
 
-include { DECONTAMINATE } from "$projectDir/modules/local/decontaminate/main"
+include { DECONTAMINATE } from "$projectDir/subworkflows/local/decontaminate/main"
 
 include { PURGE_DUPLICATES } from "$projectDir/subworkflows/local/purge_dups/main"
 

--- a/main.nf
+++ b/main.nf
@@ -71,6 +71,7 @@ workflow {
     }
 
     // Data inspection
+    ch_hifi = PREPARE_INPUT.out.hifi
     if ( 'inspect' in workflow_steps ) {
         // QC Steps
         INSPECT_DATA(
@@ -78,6 +79,7 @@ workflow {
             BUILD_HIFI_DATABASES.out.fastk_hist_ktab,
             BUILD_HIC_DATABASES.out.fastk_hist_ktab
         )
+        ch_hifi = INSPECT_DATA.out.hifi // with added kmer coverage
     }
 
     // Preprocess data
@@ -105,7 +107,7 @@ workflow {
     COMPARE_ASSEMBLIES ( ch_raw_assemblies )
     EVALUATE_RAW_ASSEMBLY (
         ch_raw_assemblies,
-        PREPARE_INPUT.out.hifi,
+        ch_hifi,
         BUILD_HIFI_DATABASES.out.fastk_hist_ktab,
     )
 
@@ -132,7 +134,7 @@ workflow {
     if ( 'purge' in workflow_steps ) {
         PURGE_DUPLICATES (
             ch_to_purge,
-            'inspect' in workflow_steps ? INSPECT_DATA.out.hifi : PREPARE_INPUT.out.hifi
+            ch_hifi
         )
         ch_purged_assemblies = PURGE_DUPLICATES.out.assemblies
     } else {
@@ -143,7 +145,7 @@ workflow {
     ).dump(tag: 'Assemblies: Purged')
     EVALUATE_PURGED_ASSEMBLY (
         ch_purged_assemblies,
-        PREPARE_INPUT.out.hifi,
+        ch_hifi,
         BUILD_HIFI_DATABASES.out.fastk_hist_ktab
     )
 

--- a/main.nf
+++ b/main.nf
@@ -100,7 +100,7 @@ workflow {
     }
     ch_raw_assemblies.dump(tag: 'Assemblies: Raw')
     // TODO: Add organelle assembly from reads
-    ASSEMBLE_ORGANELLES ( raw_assemblies )
+    ASSEMBLE_ORGANELLES ( ch_raw_assemblies )
     // TODO: filter organelles from assemblies
 
     // Assess assemblies

--- a/main.nf
+++ b/main.nf
@@ -3,7 +3,7 @@
 // Include Map.deepMerge() function
 evaluate(new File("$projectDir/lib/MapExtended.groovy"))
 
-include { dropMeta; combineByMetaKeys } from "$projectDir/modules/local/functions"
+include { combineByMetaKeys } from "$projectDir/modules/local/functions"
 
 include { PREPARE_INPUT } from "$projectDir/subworkflows/local/prepare_input/main"
 

--- a/main.nf
+++ b/main.nf
@@ -101,10 +101,7 @@ workflow {
     // TODO: filter organelles from assemblies
 
     // Assess assemblies
-    COMPARE_ASSEMBLIES (
-        ch_raw_assemblies,
-        params.reference ? file( params.reference, checkIfExists: true ) : []
-    )
+    COMPARE_ASSEMBLIES ( ch_raw_assemblies )
     EVALUATE_RAW_ASSEMBLY (
         ch_raw_assemblies,
         PREPARE_INPUT.out.hifi,

--- a/main.nf
+++ b/main.nf
@@ -107,7 +107,6 @@ workflow {
     COMPARE_ASSEMBLIES ( ch_raw_assemblies )
     EVALUATE_RAW_ASSEMBLY (
         ch_raw_assemblies,
-        ch_hifi,
         BUILD_HIFI_DATABASES.out.fastk_hist_ktab,
     )
 
@@ -145,7 +144,6 @@ workflow {
     ).dump(tag: 'Assemblies: Purged')
     EVALUATE_PURGED_ASSEMBLY (
         ch_purged_assemblies,
-        ch_hifi,
         BUILD_HIFI_DATABASES.out.fastk_hist_ktab
     )
 

--- a/main.nf
+++ b/main.nf
@@ -109,8 +109,6 @@ workflow {
         ch_raw_assemblies,
         PREPARE_INPUT.out.hifi,
         BUILD_HIFI_DATABASES.out.fastk_histogram.join( BUILD_HIFI_DATABASES.out.fastk_ktab ),
-        params.reference ? file( params.reference, checkIfExists: true ) : [],
-        params.busco.lineages_db_path ? file( params.busco.lineages_db_path, checkIfExists: true ) : []
     )
 
     // Contamination screen
@@ -148,9 +146,7 @@ workflow {
     EVALUATE_PURGED_ASSEMBLY (
         ch_purged_assemblies,
         PREPARE_INPUT.out.hifi,
-        BUILD_HIFI_DATABASES.out.fastk_histogram.join( BUILD_HIFI_DATABASES.out.fastk_ktab ),
-        params.reference ? file( params.reference, checkIfExists: true ) : [], // This makes reading it harder. Move to workflow
-        params.busco.lineages_db_path ? file( params.busco.lineages_db_path, checkIfExists: true ) : []
+        BUILD_HIFI_DATABASES.out.fastk_histogram.join( BUILD_HIFI_DATABASES.out.fastk_ktab )
     )
 
     // Polish

--- a/main.nf
+++ b/main.nf
@@ -147,34 +147,55 @@ workflow {
     )
 
     // Polish
+    ch_to_polish = setAssemblyStage (
+        ch_purged_assemblies,
+        'polished' // Set assembly stage now for filenaming
+    )
     if ( 'polish' in workflow_steps ) {
         // Run polishers
+        ch_polished_assemblies = ch_to_polish
     } else {
-        // Skip polishing. Use purged
-        // TODO. Update meta stage
+        ch_polished_assemblies = ch_to_polish
     }
+    ch_polished_assemblies = ch_polished_assemblies.mix(
+        preassembledInput( PREPARE_INPUT.out.assemblies, 'polished' )
+    )
 
     // Scaffold
+    ch_to_scaffold = setAssemblyStage (
+        ch_polished_assemblies,
+        'scaffolded' // Set assembly stage now for filenaming
+    )
     if ( 'scaffold' in workflow_steps ) {
         // Run scaffolder
+        ch_scaffolded_assemblies = ch_to_scaffold
     } else {
-        // Skip scaffolding. Use polished
-        // TODO. Update meta stage
+        ch_scaffolded_assemblies = ch_to_scaffold
     }
+    ch_scaffolded_assemblies = ch_scaffolded_assemblies.mix(
+        preassembledInput( PREPARE_INPUT.out.assemblies, 'scaffolded' )
+    )
 
     // Curate
+    ch_to_curate = setAssemblyStage (
+        ch_scaffolded_assemblies,
+        'curated' // Set assembly stage now for filenaming
+    )
     if ( 'curate' in workflow_steps ) {
         // Run assemblers
+        ch_curated_assemblies = ch_to_curate
     } else {
-        // Skip curation. Use scaffolded
-        // TODO. Update meta stage
+        ch_curated_assemblies = ch_to_curate
     }
+    ch_curated_assemblies = ch_curated_assemblies.mix(
+        preassembledInput( PREPARE_INPUT.out.assemblies, 'curated' )
+    )
 
     // Align RNAseq
     if( 'alignRNA' in workflow_steps ) {
         ALIGN_RNASEQ (
             PREPARE_INPUT.out.rnaseq,
-            PREPARE_INPUT.out.assemblies
+            PREPARE_INPUT.out.assemblies // TODO: Select assembly stage
                 .map { meta, assembly -> [ meta, assembly.pri_fasta ] }
         )
     }

--- a/modules/local/functions.nf
+++ b/modules/local/functions.nf
@@ -63,7 +63,7 @@ def assembliesFromStage( assemblies, String stage ) {
 }
 
 def setAssemblyStage( assemblies, String stage ) {
-    assemblies.map{ meta, assemblies -> [ meta.deepMerge([ assembly: [ stage: stage, build: "${meta.assembly.assembler}-${stage}-${meta.assembly.id}" ] ]), assemblies ] }
+    assemblies.map{ meta, assembly -> [ meta.deepMerge([ assembly: [ stage: stage, build: "${meta.assembly.assembler}-${stage}-${meta.assembly.id}" ] ]), assembly ] }
 }
 
 def getPrimaryAssembly( assemblies ) {

--- a/modules/local/functions.nf
+++ b/modules/local/functions.nf
@@ -65,3 +65,15 @@ def assembliesFromStage( assemblies, String stage ) {
 def setAssemblyStage( assemblies, String stage ) {
     assemblies.map{ meta, assemblies -> [ meta.deepMerge([ assembly: [ stage: stage, build: "${meta.assembly.assembler}-${stage}-${meta.assembly.id}" ] ]), assemblies ] }
 }
+
+def getPrimaryAssembly( assemblies ) {
+    assemblies.map { meta, assembly -> [ meta, assembly.pri_fasta ] }
+}
+
+def constructAssemblyRecord( assemblies ) {
+    assemblies.groupTuple( sort: { a, b -> a.name <=> b.name } )
+        .map { meta, fasta ->
+            def asm_meta = meta.assembly.subMap(['assembler','stage','id','build'])
+            [ meta, asm_meta + (fasta.size() == 1 ? [ pri_fasta: fasta[0] ] : [ pri_fasta: fasta[0], alt_fasta: fasta[1] ] ) ]
+        }
+}

--- a/modules/local/functions.nf
+++ b/modules/local/functions.nf
@@ -1,7 +1,3 @@
-def dropMeta( channel ){
-    channel.map{ it[1] }
-}
-
 def combineByMetaKeys( Map args = [:], lhs, rhs ){
     assert args.keySet != null
     def combine_args = [ by: 0 ]

--- a/modules/local/functions.nf
+++ b/modules/local/functions.nf
@@ -58,6 +58,10 @@ def joinByMetaKeys( Map args = [:], lhs, rhs ) {
     }
 }
 
-def assembliesFromStage( assemblies, String stage ){
+def assembliesFromStage( assemblies, String stage ) {
     assemblies.filter { meta, assembly -> meta.assembly?.stage == stage }
+}
+
+def setAssemblyStage( assemblies, String stage ) {
+    assemblies.map{ meta, assemblies -> [ meta.deepMerge([ assembly: [ stage: stage, build: "${meta.assembly.assembler}-${stage}-${meta.assembly.id}" ] ]), assemblies ] }
 }

--- a/modules/local/functions.nf
+++ b/modules/local/functions.nf
@@ -57,3 +57,7 @@ def joinByMetaKeys( Map args = [:], lhs, rhs ) {
             assert args.meta in ['lhs','rhs','merge','subset']
     }
 }
+
+def assembliesFromStage( assemblies, String stage ){
+    assemblies.filter { meta, assembly -> meta.assembly?.stage == stage }
+}

--- a/subworkflows/local/assemble/main.nf
+++ b/subworkflows/local/assemble/main.nf
@@ -1,0 +1,17 @@
+include { ASSEMBLE_HIFI } from "$projectDir/subworkflows/local/assemble_hifi/main"
+
+workflow ASSEMBLE {
+    take:
+    hifi_reads // [ meta, hifi_reads ]
+
+    main:
+    ch_versions = Channel.empty()
+
+    // TODO: Make strategy check
+    ASSEMBLE_HIFI( hifi_reads )
+    ch_raw_assemblies = ASSEMBLE_HIFI.out.assemblies
+
+    emit:
+    raw_assemblies = ch_raw_assemblies
+    versions = ch_versions
+}

--- a/subworkflows/local/assemble_hifi/main.nf
+++ b/subworkflows/local/assemble_hifi/main.nf
@@ -38,7 +38,7 @@ workflow ASSEMBLE_HIFI {
         )
         raw_assembly_ch = params.use_phased ? HIFIASM.out.paternal_contigs.mix( HIFIASM.out.maternal_contigs ) : HIFIASM.out.processed_contigs
         GFATOOLS_GFA2FA( raw_assembly_ch )
-        fasta_ch = GFATOOLS_GFA2FA.out.fasta.multiMap{
+        fasta_ch = GFATOOLS_GFA2FA.out.fasta.multiMap { meta, fasta ->
             fasta: [ meta, fasta ]
             genome_size: meta.sample.genome_size
         }

--- a/subworkflows/local/assemble_organelles/main.nf
+++ b/subworkflows/local/assemble_organelles/main.nf
@@ -3,7 +3,7 @@ include { MITOHIFI_MITOHIFI          } from "$projectDir/modules/nf-core/mitohif
 
 workflow ASSEMBLE_ORGANELLES {
     take:
-    raw_assemblies
+    ch_raw_assemblies
 
     main:
     ch_versions = Channel.empty()

--- a/subworkflows/local/assemble_organelles/main.nf
+++ b/subworkflows/local/assemble_organelles/main.nf
@@ -1,0 +1,35 @@
+include { MITOHIFI_FINDMITOREFERENCE } from "$projectDir/modules/nf-core/mitohifi/findmitoreference/main"
+include { MITOHIFI_MITOHIFI          } from "$projectDir/modules/nf-core/mitohifi/mitohifi/main"
+
+workflow ASSEMBLE_ORGANELLES {
+    take:
+    raw_assemblies
+
+    main:
+    ch_versions = Channel.empty()
+    // Find mitochondria
+    // TODO: Need to check options to mitohifi modules.
+    MITOHIFI_FINDMITOREFERENCE( ch_raw_assemblies.map { meta, assemblies -> [ meta, meta.sample.name ] }.unique() )
+    mitohifi_ch = ch_raw_assemblies
+        .combine(
+            MITOHIFI_FINDMITOREFERENCE.out.fasta
+                .join(MITOHIFI_FINDMITOREFERENCE.out.gb),
+            by: 0
+        )
+        .multiMap { meta, assembly, mitofa, mitogb ->
+            input: [ meta, assembly.pri_fasta ]
+            reference: mitofa
+            genbank: mitogb
+        }
+    MITOHIFI_MITOHIFI(
+        mitohifi_ch.input,
+        mitohifi_ch.reference,
+        mitohifi_ch.genbank,
+        'c',
+        params.mitohifi.code
+    )
+
+    emit:
+    // TODO: emit filtered assembly, or contig list to purge
+    versions = ch_versions
+}

--- a/subworkflows/local/build_databases/main.nf
+++ b/subworkflows/local/build_databases/main.nf
@@ -2,7 +2,7 @@ include { FASTK_FASTK     } from "$projectDir/modules/nf-core/fastk/fastk/main"
 include { FASTK_MERGE     } from "$projectDir/modules/nf-core/fastk/merge/main"
 
 workflow BUILD_DATABASES {
-    
+
     take:
     fastx_data
 
@@ -27,6 +27,7 @@ workflow BUILD_DATABASES {
     emit:
     fastk_histogram = fk_single.hist.mix(FASTK_MERGE.out.hist)
     fastk_ktab      = fk_single.ktab.mix(FASTK_MERGE.out.ktab)
+    fastk_hist_ktab = fk_single.hist.mix(FASTK_MERGE.out.hist).join(fk_single.ktab.mix(FASTK_MERGE.out.ktab))
     versions        = versions_ch
 
 }

--- a/subworkflows/local/compare_assemblies/main.nf
+++ b/subworkflows/local/compare_assemblies/main.nf
@@ -1,17 +1,16 @@
-include { QUAST } from "$projectDir/modules/nf-core/quast/main"
+include { getPrimaryAssembly } from "$projectDir/modules/local/functions"
+include { QUAST              } from "$projectDir/modules/nf-core/quast/main"
 
 workflow COMPARE_ASSEMBLIES {
 
     take:
     assembly_ch        // input type: [ [ id: 'sample_name' ], [ id:'assemblerX_build1', primary_asm_path: '/path/to/primary_asm', alternate_asm_path: '/path/to/alternate_asm' ] ]
-    reference_ch       // optional: file( reference_genome ) for comparison
 
     main:
     QUAST (
-        assembly_ch
-            .map { sample, assembly -> [ sample, assembly.pri_fasta ] }
+        getPrimaryAssembly( assembly_ch )
             .groupTuple(),
-        reference_ch,
+        params.reference ? file( params.reference, checkIfExists: true ) : [],
         []              // No GFF
     )
     versions_ch = QUAST.out.versions

--- a/subworkflows/local/decontaminate/main.nf
+++ b/subworkflows/local/decontaminate/main.nf
@@ -1,17 +1,18 @@
-include { FCSGX_FETCHDB } from "$projectDir/modules/local/fcsgx/fetchdb"
-include { FCSGX_RUNGX   } from "$projectDir/modules/local/fcsgx/rungx"
-include { FCSGX_CLEAN   } from "$projectDir/modules/local/fcsgx/clean"
+include { constructAssemblyRecord } from "$projectDir/modules/local/functions"
+include { FCSGX_FETCHDB           } from "$projectDir/modules/local/fcsgx/fetchdb"
+include { FCSGX_RUNGX             } from "$projectDir/modules/local/fcsgx/rungx"
+include { FCSGX_CLEAN             } from "$projectDir/modules/local/fcsgx/clean"
 
 workflow DECONTAMINATE {
     take:
-    ch_raw_assemblies
+    ch_assemblies // [ meta, assembly ]
 
     main:
     ch_versions = Channel.empty()
 
     FCSGX_FETCHDB ( params.fcs.database ? Channel.empty() : Channel.fromPath( params.fcs.manifest, checkIfExists: true ) )
     ch_fcs_database = params.fcs.database ? Channel.fromPath( params.fcs.database, checkIfExists: true, type: 'dir' ) : FCSGX_FETCHDB.out.database
-    ch_to_screen = ch_raw_assemblies.flatMap { meta, assembly ->
+    ch_to_screen = ch_assemblies.flatMap { meta, assembly ->
             def updated_meta = meta.deepMerge( [ assembly: [ stage: 'decontaminated', build: "${meta.assembly.assembler}-decontaminated-${meta.assembly.id}" ] ] )
             assembly.alt_fasta ? [
                 [ updated_meta + [ haplotype: 0 ], updated_meta.sample.taxid, assembly.pri_fasta ],
@@ -25,15 +26,12 @@ workflow DECONTAMINATE {
         ch_to_screen.join( FCSGX_RUNGX.out.fcs_gx_report, by: 0 )
             .map { meta, taxid, asm, rpt -> [ meta, asm, rpt ] }
     )
-    ch_cleaned_assemblies = FCSGX_CLEAN.out.clean_fasta
-        .map { meta, asm -> [ meta.subMap(meta.keySet()-['haplotype']), asm ] }
-        .groupTuple( sort: { a, b -> a.name <=> b.name } )
-        .map { meta, fasta ->
-            def asm_meta = meta.assembly.subMap(['assembler','stage','id','build'])
-            [ meta, asm_meta + (fasta.size() == 1 ? [ pri_fasta: fasta[0] ] : [ pri_fasta: fasta[0], alt_fasta: fasta[1] ] ) ]
-        }
+    ch_cleaned_assemblies = constructAssemblyRecord(
+        FCSGX_CLEAN.out.clean_fasta
+            .map { meta, asm -> [ meta.subMap(meta.keySet()-['haplotype']), asm ] }
+    )
 
     emit:
     assemblies = ch_cleaned_assemblies
-    versions = ch_versions
+    versions   = ch_versions
 }

--- a/subworkflows/local/decontaminate/main.nf
+++ b/subworkflows/local/decontaminate/main.nf
@@ -1,0 +1,39 @@
+include { FCSGX_FETCHDB } from "$projectDir/modules/local/fcsgx/fetchdb"
+include { FCSGX_RUNGX   } from "$projectDir/modules/local/fcsgx/rungx"
+include { FCSGX_CLEAN   } from "$projectDir/modules/local/fcsgx/clean"
+
+workflow DECONTAMINATE {
+    take:
+    ch_raw_assemblies
+
+    main:
+    ch_versions = Channel.empty()
+
+    FCSGX_FETCHDB ( params.fcs.database ? Channel.empty() : Channel.fromPath( params.fcs.manifest, checkIfExists: true ) )
+    ch_fcs_database = params.fcs.database ? Channel.fromPath( params.fcs.database, checkIfExists: true, type: 'dir' ) : FCSGX_FETCHDB.out.database
+    ch_to_screen = ch_raw_assemblies.flatMap { meta, assembly ->
+            def updated_meta = meta.deepMerge( [ assembly: [ stage: 'decontaminated', build: "${meta.assembly.assembler}-decontaminated-${meta.assembly.id}" ] ] )
+            assembly.alt_fasta ? [
+                [ updated_meta + [ haplotype: 0 ], updated_meta.sample.taxid, assembly.pri_fasta ],
+                [ updated_meta + [ haplotype: 1 ], updated_meta.sample.taxid, assembly.alt_fasta ]
+            ] : [
+                [ updated_meta + [ haplotype: 0 ], updated_meta.sample.taxid, assembly.pri_fasta ]
+            ]
+        }
+    FCSGX_RUNGX( ch_to_screen, ch_fcs_database.collect(), params.fcs.ramdisk_path )
+    FCSGX_CLEAN(
+        ch_to_screen.join( FCSGX_RUNGX.out.fcs_gx_report, by: 0 )
+            .map { meta, taxid, asm, rpt -> [ meta, asm, rpt ] }
+    )
+    ch_cleaned_assemblies = FCSGX_CLEAN.out.clean_fasta
+        .map { meta, asm -> [ meta.subMap(meta.keySet()-['haplotype']), asm ] }
+        .groupTuple( sort: { a, b -> a.name <=> b.name } )
+        .map { meta, fasta ->
+            def asm_meta = meta.assembly.subMap(['assembler','stage','id','build'])
+            [ meta, asm_meta + (fasta.size() == 1 ? [ pri_fasta: fasta[0] ] : [ pri_fasta: fasta[0], alt_fasta: fasta[1] ] ) ]
+        }
+
+    emit:
+    assemblies = ch_cleaned_assemblies
+    versions = ch_versions
+}

--- a/subworkflows/local/evaluate_assembly/main.nf
+++ b/subworkflows/local/evaluate_assembly/main.nf
@@ -9,8 +9,6 @@ workflow EVALUATE_ASSEMBLY {
     assembly_ch        // input type: [ meta, [ id:'assemblerX_build1', pri_fasta: '/path/to/primary_asm', alt_fasta: '/path/to/alternate_asm' ] ]
     reads_ch           // input type: [ meta, [ 'path/to/reads' ] ]
     fastk_db           // input type: [ meta, [ 'path/to/reads.hist' ], [ '/path/to/reads.ktab' ] ]
-    reference_ch       // optional: file( reference_genome ) for comparison
-    busco_lineage_path // Path to Busco lineage files
 
     main:
 
@@ -24,9 +22,6 @@ workflow EVALUATE_ASSEMBLY {
             keySet: ['id','sample'],
             meta: 'rhs'
         )
-        // fastk_db.combine( assembly_ch.map { sample, assembly ->
-        //         [ sample, ( assembly.alt_fasta ? [ assembly.pri_fasta, assembly.alt_fasta ] : assembly.pri_fasta ) ]
-        //     }, by: 0 )
     )
 
     // Evaluate core gene space coverage
@@ -49,7 +44,7 @@ workflow EVALUATE_ASSEMBLY {
         busco_input.assembly_ch,
         'genome',
         busco_input.lineage_ch,
-        busco_lineage_path,
+        params.busco.lineages_db_path ? file( params.busco.lineages_db_path, checkIfExists: true ) : [],
         []
     )
 }

--- a/subworkflows/local/evaluate_assembly/main.nf
+++ b/subworkflows/local/evaluate_assembly/main.nf
@@ -7,7 +7,6 @@ workflow EVALUATE_ASSEMBLY {
 
     take:
     assembly_ch        // input type: [ meta, [ id:'assemblerX_build1', pri_fasta: '/path/to/primary_asm', alt_fasta: '/path/to/alternate_asm' ] ]
-    reads_ch           // input type: [ meta, [ 'path/to/reads' ] ]
     fastk_db           // input type: [ meta, [ 'path/to/reads.hist' ], [ '/path/to/reads.ktab' ] ]
 
     main:

--- a/subworkflows/local/inspect_data/main.nf
+++ b/subworkflows/local/inspect_data/main.nf
@@ -1,0 +1,24 @@
+include { GENOME_PROPERTIES } from "$projectDir/subworkflows/local/genome_properties/main"
+include { COMPARE_LIBRARIES } from "$projectDir/subworkflows/local/compare_libraries/main"
+include { SCREEN_READS      } from "$projectDir/subworkflows/local/screen_read_contamination/main"
+
+workflow INSPECT_DATA {
+    take:
+    hifi_reads     // [ meta, hifi ]
+    hifi_histogram // [ meta, hifi_hist, ktab ]
+    hic_histogram  // [ meta, hic_hist, ktab ]
+
+    main:
+    ch_versions = Channel.empty()
+    // QC Steps
+    GENOME_PROPERTIES ( hifi_histogram )
+    COMPARE_LIBRARIES ( hifi_histogram.join( hic_histogram ) )
+    SCREEN_READS (
+        PREPARE_INPUT.out.hifi,
+        // TODO:: Allow custom database ala nf-core/genomeassembler.
+        file( params.mash.screen_db, checkIfExists: true )
+    )
+
+    emit:
+    versions = ch_versions
+}

--- a/subworkflows/local/inspect_data/main.nf
+++ b/subworkflows/local/inspect_data/main.nf
@@ -1,3 +1,4 @@
+include { combineByMetaKeys } from "$projectDir/modules/local/functions"
 include { GENOME_PROPERTIES } from "$projectDir/subworkflows/local/genome_properties/main"
 include { COMPARE_LIBRARIES } from "$projectDir/subworkflows/local/compare_libraries/main"
 include { SCREEN_READS      } from "$projectDir/subworkflows/local/screen_read_contamination/main"
@@ -19,6 +20,15 @@ workflow INSPECT_DATA {
         file( params.mash.screen_db, checkIfExists: true )
     )
 
+    ch_hifi_with_kmer_cov = combineByMetaKeys(
+        hifi_reads,
+        GENOME_PROPERTIES.out.kmer_cov,
+        keySet: ['id','sample'],
+        meta: 'lhs'
+    )
+    .map { meta, reads, kmer_cov -> [ meta + [ kmercov: kmer_cov ], reads ] }
+
     emit:
+    hifi     = ch_hifi_with_kmer_cov
     versions = ch_versions
 }

--- a/subworkflows/local/inspect_data/main.nf
+++ b/subworkflows/local/inspect_data/main.nf
@@ -15,7 +15,7 @@ workflow INSPECT_DATA {
     GENOME_PROPERTIES ( hifi_histogram )
     COMPARE_LIBRARIES ( hifi_histogram.join( hic_histogram ) )
     SCREEN_READS (
-        PREPARE_INPUT.out.hifi,
+        hifi_reads,
         // TODO:: Allow custom database ala nf-core/genomeassembler.
         file( params.mash.screen_db, checkIfExists: true )
     )


### PR DESCRIPTION
- Adds functions for common map operations.
- Use two channels to structure inputs and outputs of each workflow stage.
- Move certain parts around to outside stages ( need to control with other parameter flags ).
- Attempt to simplify reading of primary workflow.
- Adds output channel for common join