### PR TITLE
Add fallback for no ToL ID

### DIFF
--- a/modules/local/report/dtol.nf
+++ b/modules/local/report/dtol.nf
@@ -13,7 +13,7 @@ process REPORT_DTOL {
 
     exec:
     def tol_table = [
-        tolId: tol_search_json.species[0].tolIds[0].tolId,
+        tolId: tol_search_json.species[0].tolIds[0]?.tolId?: "No ToL ID",
         species: tol_search_json.species[0].scientificName,
         class: tol_search_json.species[0].taxaClass,
         order: tol_search_json.species[0].order


### PR DESCRIPTION
Adds a default string when no Tree of Life ID is found.

Closes #107 