### PR TITLE
Update purgedups

### DIFF
--- a/configs/modules.config
+++ b/configs/modules.config
@@ -263,7 +263,7 @@ process {
         ext.prefix = { "${meta.id}_${meta.assembly.build}_hap1" }
     }
     withName: 'PURGE_DUPLICATES:SEQKIT_SEQ' {
-        ext.prefix = { ${fastx}.getBaseName() + "_fold" }
+        ext.prefix = { "${fastx.baseName}_fold" }
         ext.args = "-w 100"
     }
     withName: 'PURGEDUPS_.*' {

--- a/configs/modules.config
+++ b/configs/modules.config
@@ -263,7 +263,7 @@ process {
         ext.prefix = { "${meta.id}_${meta.assembly.build}_hap1" }
     }
     withName: 'PURGE_DUPLICATES:SEQKIT_SEQ' {
-        ext.prefix = { "${fastx}".getBaseName()"_fold" }
+        ext.prefix = { ${fastx}.getBaseName() + "_fold" }
         ext.args = "-w 100"
     }
     withName: 'PURGEDUPS_.*' {

--- a/configs/modules.config
+++ b/configs/modules.config
@@ -262,6 +262,10 @@ process {
     withName: '(PURGEDUPS|MINIMAP2)_.*_ALTERNATE' {
         ext.prefix = { "${meta.id}_${meta.assembly.build}_hap1" }
     }
+    withName: 'PURGE_DUPLICATES:SEQKIT_SEQ' {
+        ext.prefix = { "${fastx}".getBaseName()"_fold" }
+        ext.args = "-w 100"
+    }
     withName: 'PURGEDUPS_.*' {
         tag        = { meta.assembly.build }
         publishDir = [

--- a/modules.json
+++ b/modules.json
@@ -183,6 +183,11 @@
             "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
             "installed_by": ["modules"]
           },
+          "seqkit/seq": {
+            "branch": "master",
+            "git_sha": "2be41ca2cc780eca4293d1b0dd3850b0b7ac40a3",
+            "installed_by": ["modules"]
+          },
           "star/align": {
             "branch": "master",
             "git_sha": "cc08a888069f67cab8120259bddab8032d4c0fe3",

--- a/modules/nf-core/seqkit/seq/environment.yml
+++ b/modules/nf-core/seqkit/seq/environment.yml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+name: "seqkit_seq"
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - "bioconda::seqkit=2.8.1"

--- a/modules/nf-core/seqkit/seq/main.nf
+++ b/modules/nf-core/seqkit/seq/main.nf
@@ -1,0 +1,63 @@
+process SEQKIT_SEQ {
+    tag "$meta.id"
+    label 'process_low'
+    // File IO can be a bottleneck. See: https://bioinf.shenwei.me/seqkit/usage/#parallelization-of-cpu-intensive-jobs
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/seqkit:2.8.1--h9ee0642_0':
+        'biocontainers/seqkit:2.8.1--h9ee0642_0' }"
+
+    input:
+    tuple val(meta), path(fastx)
+
+    output:
+    tuple val(meta), path("${prefix}.*")    , emit: fastx
+    path "versions.yml"                     , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args        = task.ext.args ?: ''
+    def args2       = task.ext.args2 ?: ''
+    prefix          = task.ext.prefix ?: "${meta.id}"
+    def extension   = "fastq"
+    if ("$fastx" ==~ /.+\.fasta|.+\.fasta.gz|.+\.fa|.+\.fa.gz|.+\.fas|.+\.fas.gz|.+\.fna|.+\.fna.gz|.+\.fsa|.+\.fsa.gz/ ) {
+        extension   = "fasta"
+    }
+    extension       = fastx.toString().endsWith('.gz') ? "${extension}.gz" : extension
+    def call_gzip   = extension.endsWith('.gz') ? "| gzip -c $args2" : ''
+    if("${prefix}.${extension}" == "$fastx") error "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
+    """
+    seqkit \\
+        seq \\
+        --threads $task.cpus \\
+        $args \\
+        $fastx \\
+        $call_gzip \\
+        > ${prefix}.${extension}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        seqkit: \$(seqkit version | cut -d' ' -f2)
+    END_VERSIONS
+    """
+
+    stub:
+    prefix          = task.ext.prefix ?: "${meta.id}"
+    def extension   = "fastq"
+    if ("$fastx" ==~ /.+\.fasta|.+\.fasta.gz|.+\.fa|.+\.fa.gz|.+\.fas|.+\.fas.gz|.+\.fna|.+\.fna.gz|.+\.fsa|.+\.fsa.gz/ ) {
+        extension   = "fasta"
+    }
+    extension = fastx.toString().endsWith('.gz') ? "${extension}.gz" : extension
+    if("${prefix}.${extension}" == "$fastx") error "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
+    """
+    touch ${prefix}.${extension}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        seqkit: \$(seqkit version | cut -d' ' -f2)
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/seqkit/seq/meta.yml
+++ b/modules/nf-core/seqkit/seq/meta.yml
@@ -1,0 +1,48 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "seqkit_seq"
+description: Transforms sequences (extract ID, filter by length, remove gaps, reverse complement...)
+keywords:
+  - genomics
+  - fasta
+  - fastq
+  - transform
+  - filter
+  - gaps
+  - complement
+tools:
+  - "seqkit":
+      description: "A cross-platform and ultrafast toolkit for FASTA/Q file manipulation"
+      homepage: "https://bioinf.shenwei.me/seqkit/"
+      documentation: "https://bioinf.shenwei.me/seqkit/usage/"
+      tool_dev_url: "https://github.com/shenwei356/seqkit"
+      doi: "10.1371/journal.pone.0163962"
+      licence: ["MIT"]
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. `[ id:'sample1' ]`
+  - fastx:
+      type: file
+      description: Input fasta/fastq file
+      pattern: "*.{fsa,fas,fa,fasta,fastq,fq,fsa.gz,fas.gz,fa.gz,fasta.gz,fastq.gz,fq.gz}"
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. `[ id:'sample1' ]`
+  - fastx:
+      type: file
+      description: Output fasta/fastq file
+      pattern: "*.{fasta,fasta.gz,fastq,fastq.gz}"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+authors:
+  - "@GallVp"
+maintainers:
+  - "@GallVp"

--- a/modules/nf-core/seqkit/seq/tests/main.nf.test
+++ b/modules/nf-core/seqkit/seq/tests/main.nf.test
@@ -1,0 +1,145 @@
+nextflow_process {
+
+    name "Test Process SEQKIT_SEQ"
+    script "../main.nf"
+    process "SEQKIT_SEQ"
+    config './nextflow.config'
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "seqkit"
+    tag "seqkit/seq"
+
+    test("sarscov2-genome_fasta") {
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() },
+            )
+        }
+
+    }
+
+    test("sarscov2-genome_fasta_gz") {
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.test_data['sarscov2']['genome']['genome_fasta_gz'], checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() },
+            )
+        }
+
+    }
+
+    test("sarscov2-test_1_fastq_gz") {
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() },
+            )
+        }
+
+    }
+
+    test("file_name_conflict-fail_with_error") {
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test_1' ], // meta map
+                    file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert !process.success },
+                { assert process.stdout.toString().contains("Input and output names are the same") }
+            )
+        }
+
+    }
+
+    test("sarscov2-genome_fasta-stub") {
+
+        options '-stub'
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() },
+            )
+        }
+
+    }
+
+    test("file_name_conflict-fail_with_error-stub") {
+
+        options '-stub'
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'genome' ], // meta map
+                    file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert !process.success },
+                { assert process.stdout.toString().contains("Input and output names are the same") }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/seqkit/seq/tests/main.nf.test.snap
+++ b/modules/nf-core/seqkit/seq/tests/main.nf.test.snap
@@ -1,0 +1,134 @@
+{
+    "sarscov2-genome_fasta-stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,34894c4efa5e10a923e78975a3d260dd"
+                ],
+                "fastx": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,34894c4efa5e10a923e78975a3d260dd"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-05-08T08:52:18.220051903"
+    },
+    "sarscov2-test_1_fastq_gz": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fastq.gz:md5,4161df271f9bfcd25d5845a1e220dbec"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,34894c4efa5e10a923e78975a3d260dd"
+                ],
+                "fastx": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fastq.gz:md5,4161df271f9bfcd25d5845a1e220dbec"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,34894c4efa5e10a923e78975a3d260dd"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-05-08T08:51:55.607826581"
+    },
+    "sarscov2-genome_fasta": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta:md5,483f4a5dfe60171c86ee9b7e6dff908b"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,34894c4efa5e10a923e78975a3d260dd"
+                ],
+                "fastx": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta:md5,483f4a5dfe60171c86ee9b7e6dff908b"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,34894c4efa5e10a923e78975a3d260dd"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-05-08T08:51:27.717072933"
+    },
+    "sarscov2-genome_fasta_gz": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta.gz:md5,483f4a5dfe60171c86ee9b7e6dff908b"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,34894c4efa5e10a923e78975a3d260dd"
+                ],
+                "fastx": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta.gz:md5,483f4a5dfe60171c86ee9b7e6dff908b"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,34894c4efa5e10a923e78975a3d260dd"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-05-08T08:51:37.917560104"
+    }
+}

--- a/modules/nf-core/seqkit/seq/tests/nextflow.config
+++ b/modules/nf-core/seqkit/seq/tests/nextflow.config
@@ -1,0 +1,3 @@
+process {
+    ext.args2 = '-n'
+}

--- a/modules/nf-core/seqkit/seq/tests/tags.yml
+++ b/modules/nf-core/seqkit/seq/tests/tags.yml
@@ -1,0 +1,2 @@
+seqkit/seq:
+  - "modules/nf-core/seqkit/seq/**"

--- a/subworkflows/local/purge_dups/main.nf
+++ b/subworkflows/local/purge_dups/main.nf
@@ -17,8 +17,8 @@ include { PURGEDUPS_PURGEDUPS as PURGEDUPS_PURGEDUPS_PRIMARY   } from "$projectD
 include { PURGEDUPS_PURGEDUPS as PURGEDUPS_PURGEDUPS_ALTERNATE } from "$projectDir/modules/nf-core/purgedups/purgedups"
 include { PURGEDUPS_GETSEQS as PURGEDUPS_GETSEQS_PRIMARY       } from "$projectDir/modules/nf-core/purgedups/getseqs"
 include { PURGEDUPS_GETSEQS as PURGEDUPS_GETSEQS_ALTERNATE     } from "$projectDir/modules/nf-core/purgedups/getseqs"
-include { PURGEDUPS_SEQKITSEQ as PURGEDUPS_SEQKITSEQ_PRIMARY   } from "$projectDir/modules/nf-core/seqkit/seq/main"
-include { PURGEDUPS_SEQKITSEQ as PURGEDUPS_SEQKITSEQ_ALTERNATE } from "$projectDir/modules/nf-core/seqkit/seq/main"
+include { SEQKIT_SEQ as SEQKIT_SEQ_PRIMARY                     } from "$projectDir/modules/nf-core/seqkit/seq/main"
+include { SEQKIT_SEQ as SEQKIT_SEQ_ALTERNATE                   } from "$projectDir/modules/nf-core/seqkit/seq/main"
 
 workflow PURGE_DUPLICATES {
 
@@ -80,7 +80,7 @@ workflow PURGE_DUPLICATES {
             .join( PURGEDUPS_PURGEDUPS_PRIMARY.out.bed )
     )
 
-    PURGEDUPS_SEQKITSEQ_PRIMARY(
+    SEQKIT_SEQ_PRIMARY(
         PURGEDUPS_GETSEQS_PRIMARY.out.purged
     )
 
@@ -112,11 +112,11 @@ workflow PURGE_DUPLICATES {
         PURGEDUPS_SPLITFA_ALTERNATE.out.merged_fasta
             .join( PURGEDUPS_PURGEDUPS_ALTERNATE.out.bed )
     )
-    PURGEDUPS_SEQKITSEQ_ALTERNATE(
+    SEQKIT_SEQ_ALTERNATE(
         PURGEDUPS_GETSEQS_ALTERNATE.out.purged
     )
-    ch_purged_assemblies = PURGEDUPS_SEQKITSEQ_PRIMARY.out.fastx
-        .mix(PURGEDUPS_SEQKITSEQ_ALTERNATE.out.fastx)
+    ch_purged_assemblies = SEQKIT_SEQ_PRIMARY.out.fastx
+        .mix(SEQKIT_SEQ_ALTERNATE.out.fastx)
         .groupTuple( sort: { a, b -> a.name <=> b.name } )
         .map { meta, fasta ->
             def asm_meta = meta.assembly.subMap(['assembler','stage','id','build'])


### PR DESCRIPTION
try to fix Busco following crash: `KeyError: 'Scaffold N50'`

- reason: purge_dups creates fasta files without line wraps. In case of very contiguous contigs Busco (version 5.5.0) is crashing at the very final step, when it just computes the contig and scaffold N50's for the json summary file. 

- solution: fold all purged assembly files with [seqkit seq](https://nf-co.re/modules/seqkit_seq)

- other changes: 
     - purge_dups crashed when it was running with multiple read files 