### PR TITLE
Add parameter to make organelle assembly optional

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -114,9 +114,14 @@ workflow {
         // Nothing more than evaluate
     }
     ch_raw_assemblies.dump(tag: 'Assemblies: Raw')
-    // TODO: Add organelle assembly from reads
-    ASSEMBLE_ORGANELLES ( ch_raw_assemblies )
-    // TODO: filter organelles from assemblies
+
+    // Organelle assembly
+    if ( params.organelle_assembly_mode == 'reads' ) {
+        // TODO: Add organelle assembly from reads
+    } else if ( params.organelle_assembly_mode == 'contigs' ){
+        ASSEMBLE_ORGANELLES ( ch_raw_assemblies )
+        // TODO: filter organelles from assemblies
+    } // else params.organelle_assembly_mode == 'none'
 
     // Assess assemblies
     COMPARE_ASSEMBLIES ( ch_raw_assemblies )

--- a/nextflow.config
+++ b/nextflow.config
@@ -18,6 +18,7 @@ params {
     reference          = null
 
     steps              = 'inspect,preprocess,assemble,purge,polish,screen,scaffold,curate'
+    organelle_assembly_mode = 'contigs'
 
     // Workflow outputs
     outdir             = 'results'


### PR DESCRIPTION
Add a parameter to decide how to assemble organelles. 
( values: 'reads', 'contigs', 'none' ; not enforced atm).

The configuration option needed to run until completion ignoring failures is not yet in the main release of nextflow.
I think setting `workflow.failOnIgnore` to false should be the solution to this in the end.

If it Mitohifi fails, this should allow you continue without issue, or alternatively, disable it first and run, and then try the organelle assembly at the end by changing the parameter. The rest should stay cached, until we implement the filtering step.
