### PR TITLE
Add check to tell user if GOAT failed

### DIFF
--- a/subworkflows/local/prepare_input/main.nf
+++ b/subworkflows/local/prepare_input/main.nf
@@ -153,6 +153,7 @@ workflow PREPARE_INPUT {
         .map { meta, tsv ->
             def busco_lineages = tsv.splitCsv( sep:"\t", header: true ).findAll { it.odb10_lineage }.collect { it.odb10_lineage }.join(',')
             def species = tsv.splitCsv( sep:"\t", header: true ).find { it.scientific_name == meta.sample.name }
+            assert species != null : "GOAT_TAXONSEARCH failed to retrieve species information"
             meta.deepMerge([
                 sample: [
                     genome_size: meta.sample.genome_size ?: species.genome_size,


### PR DESCRIPTION
The goat cli doesn't error if it fails to retrieve species info. 
Add an assert to check.