### PR TITLE
Patch FastK merged DB to prevent filename collision in Kat Comp

### DIFF
--- a/configs/modules.config
+++ b/configs/modules.config
@@ -34,19 +34,23 @@ process {
     }
 
     // BUILD FASTK DATABASES
-    withName: 'FASTK_FASTK' {
+    withName: 'BUILD_FASTK_HIFI_DATABASE:FASTK_FASTK' {
         scratch    = false  // !Disable scratch to get around bug https://github.com/nextflow-io/nextflow/issues/2983
         ext.args   = { "-t1 -k${params.fastk?.kmer_size?:31}" }
-    }
-    withName: 'FASTK_MERGE' {
-        scratch    = false  // !Disable scratch to get around bug https://github.com/nextflow-io/nextflow/issues/2983
-        ext.prefix = { "${meta.id}_merged" }
-    }
-    withName: 'BUILD_FASTK_HIFI_DATABASE:FASTK_FASTK' {
         ext.prefix = { "${meta.id}_${reads instanceof List ? reads[0].baseName : reads.baseName}_hifi" }
     }
     withName: 'BUILD_FASTK_HIC_DATABASE:FASTK_FASTK' {
+        scratch    = false  // !Disable scratch to get around bug https://github.com/nextflow-io/nextflow/issues/2983
+        ext.args   = { "-t1 -k${params.fastk?.kmer_size?:31}" }
         ext.prefix = { "${meta.id}_${reads instanceof List ? reads[0].baseName : reads.baseName}_hic" }
+    }
+    withName: 'BUILD_FASTK_HIFI_DATABASE:FASTK_MERGE' {
+        scratch    = false  // !Disable scratch to get around bug https://github.com/nextflow-io/nextflow/issues/2983
+        ext.prefix = { "${meta.id}_merged_hifi" }
+    }
+    withName: 'BUILD_FASTK_HIC_DATABASE:FASTK_MERGE' {
+        scratch    = false  // !Disable scratch to get around bug https://github.com/nextflow-io/nextflow/issues/2983
+        ext.prefix = { "${meta.id}_merged_hic" }
     }
     withName: 'BUILD_MERYL_HIFI_DATABASE:MERYL_UNIONSUM' {
         ext.prefix = { "${meta.id}_hifi" }


### PR DESCRIPTION
The merged db's do not have the library type in the name, which caused filename collisions in `KAT_COMP`. The prefixes have now been changed to add library type which should prevent filename collisions.