### PR TITLE
Add fcs.ramdisk_path parameter to nac profile

### DIFF
--- a/configs/nac.config
+++ b/configs/nac.config
@@ -1,5 +1,10 @@
 includeConfig 'tool_resources.config'
 
+params {
+    // NAC does not have enough memory to have the db in ram. (Slows FCSGX down a lot.)
+    fcs.ramdisk_path = ''
+}
+
 process {
     // resource limits are based on most nodes of the abc partition on nac:
     // 15    CfgTRES=cpu=16,mem=120G,billing=16
@@ -12,7 +17,7 @@ process {
         time: 30.d
     ]
     // all processes that need more than the default resources need to be added here:
-    // BUT the nac cluster does not have a single node with enough storage -> this 
+    // BUT the nac cluster does not have a single node with enough storage -> this
     // results in a very long runtime due swapping issues, but in principle it should run
     withName: 'FCSGX_RUNGX' {
         cpus       = 16
@@ -23,9 +28,9 @@ process {
             memory: 370.GB,
             time: 30.d
         ]
-    } 
+    }
 
-        
+
     executor     = 'slurm'
     scratch      = '/scratch'
 }


### PR DESCRIPTION
Removes ramdisk path from FCSGX in nac profile.