### PR TITLE
Patch GOAT bypass, and executor warnings

### DIFF
--- a/configs/modules.config
+++ b/configs/modules.config
@@ -17,6 +17,9 @@ process {
     // withName: 'UNTAR_TAXONOMY' {
     //     storeDir   = { params.cache }
     // }
+    withName: 'ENA_TAXQUERY' {
+        executor = 'local'
+    }
     withName: 'GOAT_TAXONSEARCH' {
         ext.args   = "--lineage --variables odb10_lineage,haploid_number,genome_size,ploidy"
         publishDir = [
@@ -531,16 +534,4 @@ process {
             overwrite: true
         ]
     }
-    // withName: 'QUARTO' {
-    //     ext.args    = '-P image_path:data'
-    //     ext.prefix  = { "${notebook.baseName}_mqc" }
-    //     stageInMode = 'copy'
-    // }
-    // withName: 'MULTIQC' {
-    //     publishDir = [
-    //         path: { "$params.outdir/$stage.report" },
-    //         mode: params.publish_mode,
-    //         saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-    //     ]
-    // }
 }

--- a/configs/test.config
+++ b/configs/test.config
@@ -55,7 +55,4 @@ process {
         ext.args = { '-f 0' }
     }
 
-    // withName: 'ASSEMBLY_REPORT:QUARTO' {
-    //     containerOptions = { 'docker' in workflow.profile.tokenize(',')? '--platform=linux/amd64' : '' }
-    // }
 }

--- a/configs/tool_resources.config
+++ b/configs/tool_resources.config
@@ -5,7 +5,7 @@ process {
         cpus       = { Math.min(6, consensus instanceof List ? consensus.size() : 1 ) }
     }
 
-    // EVALUATE ASSEMBLIES 
+    // EVALUATE ASSEMBLIES
     withName: 'BUSCO' {
         time   = { meta.sample.genome_size.toInteger() > 3000000000 ? 4.d : 2.d }
         cpus   = { meta.sample.genome_size.toInteger() > 3000000000 ? 40 : 30 }
@@ -23,7 +23,7 @@ process {
         time       = 1.h
     }
 
-    // scaffolding - pairtools parse 
+    // scaffolding - pairtools parse
     // runs single threaded but uses 3 decompression and 8 compression threads by default
     // the runtime heavily depends on the HiC file and potentially on IO-load
     withName: 'PAIRTOOLS_PARSE' {
@@ -79,7 +79,7 @@ process {
         cpus   = { meta.sample.genome_size.toInteger() > 3000000000 ? 72 : 24 }
         memory = { meta.sample.genome_size.toInteger() > 3000000000 ? 288.GB : 96.GB }
     }
-    // MERYL_UNIONSUM does not scale well with more threads 
+    // MERYL_UNIONSUM does not scale well with more threads
     withName: 'MERYL_UNIONSUM' {
         time   = { meta.sample.genome_size.toInteger() > 3000000000 ? 12.h : 8.h }
         cpus   = { meta.sample.genome_size.toInteger() > 3000000000 ? 48 : 16 }
@@ -159,13 +159,5 @@ process {
 
     withName: 'PRETEXTMAP' {
         memory     = 30.GB
-    }
-
-    // Assembly report
-    withName: 'QUARTO' {
-        time        = 15.m
-    }
-    withName: 'MULTIQC' {
-        time       = 30.m
     }
 }

--- a/subworkflows/local/fetch_sample_metadata/main.nf
+++ b/subworkflows/local/fetch_sample_metadata/main.nf
@@ -60,6 +60,12 @@ workflow FETCH_SAMPLE_METADATA {
                         settings: [ busco: [ lineages: params.busco.lineages?: busco_lineages ] ]
                     ]
                 )
+            } else {
+                updated_metadata = updated_metadata.deepMerge(
+                    [
+                        settings: [ busco: [ lineages: params.busco.lineages ] ]
+                    ]
+                )
             }
             updated_metadata
         }


### PR DESCRIPTION
- Bug Fix. Includes busco lineage when meta data is already given supplied
- Removes executor warnings from logs