### PR TITLE
add multiple HiC mapping and filtering pipelines - be consistent in scaffolding and curation subworkflows

### DIFF
--- a/configs/modules.config
+++ b/configs/modules.config
@@ -355,7 +355,7 @@ process {
     }
 
     // scaffolding
-    withName: 'BWAMEM2_MEM_SCAFFOLD' {
+    withName: 'SCAFFOLD.*:BWAMEM2_MEM' {
         ext.prefix = { "${meta.id}_${meta.assembly.build}_${reads.head().getBaseName(reads.head().name.endsWith(".gz") ? 2 : 1)}" }
         ext.args   = '-SP -T0'
         ext.args2  = { sort_bam ? "--write-index" : "" }
@@ -369,6 +369,11 @@ process {
             mode: params.publish_mode,
             pattern: "*.pairsam.stat"
         ]
+    }
+
+    withName: '.*:SCAFFOLD_ARIMA_BWA:SAMTOOLS_SORT' {
+        ext.prefix = { "${meta.id}_${meta.assembly.build}_sortByName" }
+        ext.args   = '-n'
     }
 
     withName: 'PAIRTOOLS_SORT' {
@@ -393,6 +398,10 @@ process {
     withName: 'PAIRTOOLS_SPLIT' {
         ext.prefix = { "${meta.id}_${meta.assembly.build}" }
         ext.args2  = { sort_bam ? params.hic_bam_sorting == "by_coordinate" ? "--write-index" : "-n" : "" }
+    }
+
+    withName: 'SCAFFOLD.*:BIOBAMBAM_BAMMARKDUPLICATES2' {
+        ext.prefix = { "${bam.getBaseName(1)}_dupMarked" }
     }
 
     withName: 'YAHS' {

--- a/nextflow.config
+++ b/nextflow.config
@@ -62,6 +62,12 @@ params {
     // General module configuration
     multiqc.config         = "$projectDir/configs/multiqc_conf.yaml"
     multiqc_assembly_report_config = "$projectDir/configs/multiqc_assembly_report_config.yml"
+
+    // define HiC mapping pipeline [ "bwa", "bwa-mem2", "minimap2", "strobealign", "" ]
+    hic_mapper             = 'bwa-mem2' 
+    // define HiC workflow strategy [ "arima", "omni-c", "sanger" ]
+    hic_pipeline           = 'arima'
+
     // define HiC sequencing type [ "arima_v2", "arima_v1", "omni-c", "" ]
     hic_type               = 'arima_v2'
     // define how to sort the final HiC bam file: [ by_coordinate, by_name ]

--- a/subworkflows/local/scaffold/main.nf
+++ b/subworkflows/local/scaffold/main.nf
@@ -1,17 +1,5 @@
-include { constructAssemblyRecord                 } from "$projectDir/modules/local/functions"
-include { getPrimaryAssembly                      } from "$projectDir/modules/local/functions"
-include { joinByMetaKeys                          } from "$projectDir/modules/local/functions"
-include { combineByMetaKeys                       } from "$projectDir/modules/local/functions"
-include { BWAMEM2_INDEX as BWAMEM2_INDEX_SCAFFOLD } from "$projectDir/modules/nf-core/bwamem2/index/main"
-include { BWAMEM2_MEM as BWAMEM2_MEM_SCAFFOLD     } from "$projectDir/modules/nf-core/bwamem2/mem/main"
-include { SAMTOOLS_FAIDX                          } from "$projectDir/modules/nf-core/samtools/faidx/main"
-include { PAIRTOOLS_PARSE                         } from "$projectDir/modules/nf-core/pairtools/parse/main"
-include { PAIRTOOLS_SORT                          } from "$projectDir/modules/nf-core/pairtools/sort/main"
-include { PAIRTOOLS_MERGE                         } from "$projectDir/modules/nf-core/pairtools/merge/main"
-include { PAIRTOOLS_DEDUP                         } from "$projectDir/modules/nf-core/pairtools/dedup/main"
-include { PAIRTOOLS_SPLIT                         } from "$projectDir/modules/nf-core/pairtools/split/main"
-include { YAHS                                    } from "$projectDir/modules/nf-core/yahs/main.nf"
-
+include { SCAFFOLD_OMNIC_BWA      } from "./scaffold_omnic_bwa"
+include { SCAFFOLD_ARIMA_BWA      } from "./scaffold_arima_bwa"
 
 workflow SCAFFOLD {
     take:
@@ -20,135 +8,33 @@ workflow SCAFFOLD {
 
     main:
 
-    BWAMEM2_INDEX_SCAFFOLD ( getPrimaryAssembly(ch_assemblies) )
+    ch_versions              = Channel.empty()
+    ch_scaffolded_assemblies = Channel.empty()
+    ch_logs                  = Channel.empty()
 
-    SAMTOOLS_FAIDX (
-        getPrimaryAssembly(ch_assemblies),
-        [ [ ], [ ] ]
-    )
-
-    combineByMetaKeys( // Combine (Hi-C + index) with Assembly
-        combineByMetaKeys( // Combine Hi-C reads with BWA index
-            ch_hic,
-            BWAMEM2_INDEX_SCAFFOLD.out.index,
-            keySet: ['id','sample'],
-            meta: 'rhs'
-        ),
-        getPrimaryAssembly( ch_assemblies ),
-        keySet: ['id','sample'],
-        meta: 'rhs'
-    ).multiMap{ meta, hic_reads, index, fasta ->
-        reads: [ meta, hic_reads ]
-        index: [ meta, index ]
-        fasta: [ meta, fasta ]
-    }.set{ bwamem2_input }
-
-    BWAMEM2_MEM_SCAFFOLD (
-        bwamem2_input.reads,
-        bwamem2_input.index,
-        bwamem2_input.fasta,
-        false
-    )
-
-    SAMTOOLS_FAIDX.out.fai
-        .map{ meta, fai ->
-            fai.splitCsv( sep: '\t', header: false )
-                .collect{ row -> row[ 0..1 ].join('\t') }
-                .join('\n')
-        }.collectFile()
-        .set { chrom_sizes }
-
-    // Combine hi-c alignment with chrom sizes
-    BWAMEM2_MEM_SCAFFOLD.out.bam.combine(chrom_sizes)
-        .multiMap{ meta, hic_bam, chr_lengths ->
-            hicbams: [ meta, hic_bam ]
-            lengths: chr_lengths
-        }.set{ pairtools_parse_input }
-
-    PAIRTOOLS_PARSE (
-        pairtools_parse_input.hicbams,
-        pairtools_parse_input.lengths
-    )
-    PAIRTOOLS_SORT(PAIRTOOLS_PARSE.out.pairsam)
-    PAIRTOOLS_SORT.out.sorted.groupTuple()
-        .branch { meta, pairsam ->
-            single: pairsam.size() == 1
-                return [ meta, *pairsam ]
-            multi: true
-                return [ meta, pairsam ]
-        }
-        .set { pairtools_sorted }
-    PAIRTOOLS_MERGE(pairtools_sorted.multi)
-    PAIRTOOLS_DEDUP(
-        PAIRTOOLS_MERGE.out.pairs.mix(
-            pairtools_sorted.single
+    if (params.hic_pipeline == 'omni-c')
+    {
+        SCAFFOLD_OMNIC_BWA(
+            ch_assemblies,
+            ch_hic
         )
-    )
-
-    joinByMetaKeys(
-        PAIRTOOLS_DEDUP.out.pairs,
-        getPrimaryAssembly(ch_assemblies),
-        keySet: ['id','sample'],
-        meta: 'rhs'
-    ).multiMap{ meta, pairs, fasta ->
-        pairs: [ meta, pairs ]
-        fasta: [ meta, fasta ]
-    }.set { pairtools_split_input }
-
-    PAIRTOOLS_SPLIT(
-        pairtools_split_input.pairs,
-        pairtools_split_input.fasta,
-        true    // sort_bam
-    )
-
-    combineByMetaKeys( // Combine (bam + assembly) with fai
-        combineByMetaKeys( // Combine bams with assembly
-            PAIRTOOLS_SPLIT.out.bam,
-            getPrimaryAssembly(ch_assemblies),
-            keySet: ['id','sample'],
-            meta: 'rhs'
-        ),
-        SAMTOOLS_FAIDX.out.fai,
-        keySet: ['id','sample'],
-        meta: 'rhs'
-    ).multiMap{ meta, bam, fasta, fai ->
-        bam:   [ meta, bam ]
-        fasta: [ fasta ]
-        fai:   [ fai ]
-    }.set{ yahs_input }
-
-    YAHS(
-        yahs_input.bam,
-        yahs_input.fasta,
-        yahs_input.fai
-    )
-
-    // Consensus case:
-    // Preserve haplotigs from purge dups
-    ch_scaff_and_alt = ch_assemblies.map { meta, assembly -> [ meta, assembly.alt_fasta ] }
-        .mix( YAHS.out.scaffolds_fasta )
-    ch_scaffolded_assemblies = constructAssemblyRecord( ch_scaff_and_alt, false )
-
-    PAIRTOOLS_PARSE.out.stat
-        .mix (
-            PAIRTOOLS_DEDUP.out.stat
+        ch_versions = ch_versions.mix(SCAFFOLD_OMNIC_BWA.out.versions)
+        ch_scaffolded_assemblies = ch_scaffolded_assemblies.mix(SCAFFOLD_OMNIC_BWA.out.assemblies)
+        ch_logs = ch_logs.mix(SCAFFOLD_OMNIC_BWA.out.logs)
+    }
+    else if (params.hic_pipeline == 'arima')
+    {
+        SCAFFOLD_ARIMA_BWA(
+            ch_assemblies,
+            ch_hic
         )
-        .map { meta, stats -> stats }
-        .set { logs }
-
-    ch_versions = BWAMEM2_INDEX_SCAFFOLD.out.versions.first().mix(
-        SAMTOOLS_FAIDX.out.versions.first(),
-        BWAMEM2_MEM_SCAFFOLD.out.versions.first(),
-        PAIRTOOLS_PARSE.out.versions.first(),
-        PAIRTOOLS_SORT.out.versions.first(),
-        PAIRTOOLS_MERGE.out.versions.first(),
-        PAIRTOOLS_DEDUP.out.versions.first(),
-        PAIRTOOLS_SPLIT.out.versions.first(),
-        YAHS.out.versions.first()
-    )
+        ch_versions = ch_versions.mix(SCAFFOLD_ARIMA_BWA.out.versions)
+        ch_scaffolded_assemblies = ch_scaffolded_assemblies.mix(SCAFFOLD_ARIMA_BWA.out.assemblies)
+        ch_logs = ch_logs.mix(SCAFFOLD_ARIMA_BWA.out.logs)
+    }
 
     emit:
     assemblies = ch_scaffolded_assemblies
-    logs
+    logs       = ch_logs
     versions   = ch_versions
 }

--- a/subworkflows/local/scaffold/scaffold_arima_bwa.nf
+++ b/subworkflows/local/scaffold/scaffold_arima_bwa.nf
@@ -1,0 +1,137 @@
+include { constructAssemblyRecord               } from "../../../modules/local/functions"
+include { getPrimaryAssembly                    } from "../../../modules/local/functions"
+include { combineByMetaKeys                     } from "../../../modules/local/functions"
+include { joinByMetaKeys                        } from "../../../modules/local/functions"
+include { BWAMEM2_INDEX                         } from "../../../modules/nf-core/bwamem2/index/main"
+include { BWAMEM2_MEM                           } from "../../../modules/nf-core/bwamem2/mem/main"
+include { FILTER_FIVE_END                       } from "../../../modules/local/hic_curation/filter_five_end"
+include { TWOREADCOMBINER_FIXMATE_SORT          } from "../../../modules/local/hic_curation/tworeadcombiner_fixmate_sort"
+include { BIOBAMBAM_BAMMARKDUPLICATES2          } from "../../../modules/nf-core/biobambam/bammarkduplicates2/main"
+include { SAMTOOLS_FAIDX                        } from "../../../modules/nf-core/samtools/faidx/main"
+include { SAMTOOLS_MERGE                        } from "../../../modules/nf-core/samtools/merge/main"
+include { SAMTOOLS_SORT                         } from "../../../modules/nf-core/samtools/sort/main"
+include { YAHS                                  } from "../../../modules/nf-core/yahs/main"
+
+workflow SCAFFOLD_ARIMA_BWA {
+    take:
+    ch_assemblies // [ meta, assembly ]
+    ch_hic        // [ meta, hic-pairs ]
+
+    main:
+
+    ch_versions = Channel.empty()
+
+    BWAMEM2_INDEX(getPrimaryAssembly(ch_assemblies))
+    ch_versions = ch_versions.mix(BWAMEM2_INDEX.out.versions.first())
+
+    SAMTOOLS_FAIDX(
+        getPrimaryAssembly(ch_assemblies),
+        [[], []],
+    )
+    ch_versions = ch_versions.mix(SAMTOOLS_FAIDX.out.versions.first())
+
+    combineByMetaKeys(
+        combineByMetaKeys(
+            ch_hic,
+            BWAMEM2_INDEX.out.index,
+            keySet: ['id', 'sample'],
+            meta: 'merge',
+        ),
+        getPrimaryAssembly(ch_assemblies),
+        keySet: ['id', 'sample'],
+        meta: 'merge',
+    ).transpose(by: 1).multiMap { meta, hic_reads, index, fasta ->
+        reads: [meta, hic_reads]
+        index: [meta, index]
+        fasta: [meta, fasta]
+    }.set { bwamem2_input }
+
+    BWAMEM2_MEM(
+        bwamem2_input.reads,
+        bwamem2_input.index,
+        bwamem2_input.fasta,
+        false,
+    )
+    ch_versions = ch_versions.mix(BWAMEM2_MEM.out.versions.first())
+
+    // filter alignments
+    FILTER_FIVE_END(BWAMEM2_MEM.out.bam)
+    ch_versions = ch_versions.mix(FILTER_FIVE_END.out.versions.first())
+
+    // combine reads
+    FILTER_FIVE_END.out.bam
+        .map { meta, bam -> [meta.subMap('id', 'sample', 'assembly', 'pair_id'), bam] }
+        .groupTuple(sort: { a, b -> a.name <=> b.name })
+        .set { combine_input }
+
+    TWOREADCOMBINER_FIXMATE_SORT(combine_input)
+    ch_versions = ch_versions.mix(TWOREADCOMBINER_FIXMATE_SORT.out.versions.first())
+
+    // merge bam files in case multiple HIC paired-end libraries are present
+    TWOREADCOMBINER_FIXMATE_SORT.out.bam
+        .map { meta, bam_list -> [meta - meta.subMap('pair_id'), bam_list] }
+        .groupTuple()
+        .branch { meta, bam_list ->
+            multiples: bam_list.size() > 1
+            singleton: true
+        }
+        .set { merge_bam }
+
+    SAMTOOLS_MERGE(
+        merge_bam.multiples,
+        [[], []],
+        [[], []],
+    )
+    ch_versions = ch_versions.mix(SAMTOOLS_MERGE.out.versions.first())
+
+    merge_bam.singleton
+        .map { meta, bam -> [meta, bam.first()] }
+        .mix(SAMTOOLS_MERGE.out.bam)
+        .set { dedup_bam }
+
+    // dedupliucate bam file
+    BIOBAMBAM_BAMMARKDUPLICATES2(dedup_bam)
+    ch_versions = ch_versions.mix(BIOBAMBAM_BAMMARKDUPLICATES2.out.versions.first())
+
+    // convert bam to sorted bed file
+    SAMTOOLS_SORT(
+        BIOBAMBAM_BAMMARKDUPLICATES2.out.bam,  // [ meta,  bam ]
+        [[],[]]                                // [ meta2, reference_fasta ] --> not used 
+    )
+    ch_versions = ch_versions.mix(SAMTOOLS_SORT.out.versions.first())
+
+    combineByMetaKeys(
+        combineByMetaKeys(
+            SAMTOOLS_SORT.out.bam,
+            getPrimaryAssembly(ch_assemblies),
+            keySet: ['id', 'sample'],
+            meta: 'rhs',
+        ),
+        SAMTOOLS_FAIDX.out.fai,
+        keySet: ['id', 'sample'],
+        meta: 'rhs',
+    ).multiMap { meta, bam, fasta, fai ->
+        bam: [meta, bam]
+        fasta: [fasta]
+        fai: [fai]
+    }.set { yahs_input }
+
+    YAHS(
+        yahs_input.bam,
+        yahs_input.fasta,
+        yahs_input.fai,
+    )
+    ch_versions = ch_versions.mix(YAHS.out.versions.first())
+
+    // Consensus case:
+    // Preserve haplotigs from purge dups
+    ch_scaff_and_alt = ch_assemblies
+        .map { meta, assembly -> [meta, assembly.alt_fasta] }
+        .mix(YAHS.out.scaffolds_fasta)
+    ch_scaffolded_assemblies = constructAssemblyRecord(ch_scaff_and_alt, false)
+
+    emit:
+    assemblies = ch_scaffolded_assemblies
+    logs       = []
+    versions   = ch_versions
+}

--- a/subworkflows/local/scaffold/scaffold_omnic_bwa.nf
+++ b/subworkflows/local/scaffold/scaffold_omnic_bwa.nf
@@ -1,0 +1,165 @@
+include { constructAssemblyRecord                 } from "../../../modules/local/functions"
+include { getPrimaryAssembly                      } from "../../../modules/local/functions"
+include { joinByMetaKeys                          } from "../../../modules/local/functions"
+include { combineByMetaKeys                       } from "../../../modules/local/functions"
+include { BWAMEM2_INDEX                           } from "../../../modules/nf-core/bwamem2/index/main"
+include { BWAMEM2_MEM                             } from "../../../modules/nf-core/bwamem2/mem/main"
+include { SAMTOOLS_FAIDX                          } from "../../../modules/nf-core/samtools/faidx/main"
+include { PAIRTOOLS_PARSE                         } from "../../../modules/nf-core/pairtools/parse/main"
+include { PAIRTOOLS_SORT                          } from "../../../modules/nf-core/pairtools/sort/main"
+include { PAIRTOOLS_MERGE                         } from "../../../modules/nf-core/pairtools/merge/main"
+include { PAIRTOOLS_DEDUP                         } from "../../../modules/nf-core/pairtools/dedup/main"
+include { PAIRTOOLS_SPLIT                         } from "../../../modules/nf-core/pairtools/split/main"
+include { YAHS                                    } from "../../../modules/nf-core/yahs/main.nf"
+
+
+workflow SCAFFOLD_OMNIC_BWA {
+    take:
+    ch_assemblies // [ meta, assembly ]
+    ch_hic        // [ meta, hic-pairs ]
+
+    main:
+
+    ch_versions = Channel.empty()
+
+    BWAMEM2_INDEX(getPrimaryAssembly(ch_assemblies))
+    ch_versions = ch_versions.mix(BWAMEM2_INDEX.out.versions.first())
+
+
+    SAMTOOLS_FAIDX(
+        getPrimaryAssembly(ch_assemblies),
+        [[], []],
+    )
+    ch_versions = ch_versions.mix(SAMTOOLS_FAIDX.out.versions.first())
+
+    combineByMetaKeys(
+        combineByMetaKeys(
+            ch_hic,
+            BWAMEM2_INDEX.out.index,
+            keySet: ['id', 'sample'],
+            meta: 'rhs',
+        ),
+        getPrimaryAssembly(ch_assemblies),
+        keySet: ['id', 'sample'],
+        meta: 'rhs',
+    ).multiMap { meta, hic_reads, index, fasta ->
+        reads: [meta, hic_reads]
+        index: [meta, index]
+        fasta: [meta, fasta]
+    }.set { bwamem2_input }
+
+    BWAMEM2_MEM(
+        bwamem2_input.reads,
+        bwamem2_input.index,
+        bwamem2_input.fasta,
+        false,
+    )
+    ch_versions = ch_versions.mix(BWAMEM2_MEM.out.versions.first())
+
+    SAMTOOLS_FAIDX.out.fai
+        .map { meta, fai ->
+            fai
+                .splitCsv(sep: '\t', header: false)
+                .collect { row -> row[0..1].join('\t') }
+                .join('\n')
+        }
+        .collectFile()
+        .set { chrom_sizes }
+
+    // Combine hi-c alignment with chrom sizes
+    BWAMEM2_MEM.out.bam
+        .combine(chrom_sizes)
+        .multiMap { meta, hic_bam, chr_lengths ->
+            hicbams: [meta, hic_bam]
+            lengths: chr_lengths
+        }
+        .set { pairtools_parse_input }
+
+    PAIRTOOLS_PARSE(
+        pairtools_parse_input.hicbams,
+        pairtools_parse_input.lengths,
+    )
+    ch_versions = ch_versions.mix(PAIRTOOLS_PARSE.out.versions.first())
+
+    PAIRTOOLS_SORT(PAIRTOOLS_PARSE.out.pairsam)
+    ch_versions = ch_versions.mix(PAIRTOOLS_SORT.out.versions.first())
+
+    PAIRTOOLS_SORT.out.sorted
+        .groupTuple()
+        .branch { meta, pairsam ->
+            single: pairsam.size() == 1
+            return [meta, pairsam.first()]
+            multi: true
+            return [meta, pairsam]
+        }
+        .set { pairtools_sorted }
+
+    PAIRTOOLS_MERGE(pairtools_sorted.multi)
+    ch_versions = ch_versions.mix(PAIRTOOLS_MERGE.out.versions.first())
+
+    PAIRTOOLS_DEDUP(
+        PAIRTOOLS_MERGE.out.pairs.mix(
+            pairtools_sorted.single
+        )
+    )
+    ch_versions = ch_versions.mix(PAIRTOOLS_DEDUP.out.versions.first())
+
+    joinByMetaKeys(
+        PAIRTOOLS_DEDUP.out.pairs,
+        getPrimaryAssembly(ch_assemblies),
+        keySet: ['id', 'sample'],
+        meta: 'rhs',
+    ).multiMap { meta, pairs, fasta ->
+        pairs: [meta, pairs]
+        fasta: [meta, fasta]
+    }.set { pairtools_split_input }
+
+    PAIRTOOLS_SPLIT(
+        pairtools_split_input.pairs,
+        pairtools_split_input.fasta,
+        true,
+    )
+    ch_versions = ch_versions.mix(PAIRTOOLS_SPLIT.out.versions.first())
+
+    combineByMetaKeys(
+        combineByMetaKeys(
+            PAIRTOOLS_SPLIT.out.bam,
+            getPrimaryAssembly(ch_assemblies),
+            keySet: ['id', 'sample'],
+            meta: 'rhs',
+        ),
+        SAMTOOLS_FAIDX.out.fai,
+        keySet: ['id', 'sample'],
+        meta: 'rhs',
+    ).multiMap { meta, bam, fasta, fai ->
+        bam: [meta, bam]
+        fasta: [fasta]
+        fai: [fai]
+    }.set { yahs_input }
+
+    YAHS(
+        yahs_input.bam,
+        yahs_input.fasta,
+        yahs_input.fai,
+    )
+    ch_versions = ch_versions.mix(YAHS.out.versions.first())
+
+    // Consensus case:
+    // Preserve haplotigs from purge dups
+    ch_scaff_and_alt = ch_assemblies
+        .map { meta, assembly -> [meta, assembly.alt_fasta] }
+        .mix(YAHS.out.scaffolds_fasta)
+    ch_scaffolded_assemblies = constructAssemblyRecord(ch_scaff_and_alt, false)
+
+    PAIRTOOLS_PARSE.out.stat
+        .mix(
+            PAIRTOOLS_DEDUP.out.stat
+        )
+        .map { meta, stats -> stats }
+        .set { logs }
+
+    emit:
+    assemblies = ch_scaffolded_assemblies
+    logs
+    versions   = ch_versions
+}


### PR DESCRIPTION
initial commit that includes separate OmniC and Arima subworkflows that covers the yahs scaffolding subworkflow 

aligner: bwamem2  (for now)

not implemented yet: 
- different mapping tools (minimap2, strobealign)
- sanger HiC subworkflow 

aim of this PR: 
- discuss best practices how to include multiple HiC mapping pipelines which can use different alignment tools 
- these should be consistent in the scaffolding step as well as in the curation step 
