### PR TITLE
Update bash shell directive

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -87,14 +87,14 @@ singularity.registry = 'quay.io'
 includeConfig 'configs/nf-core-defaults.config'
 
 // Set bash options
-process.shell = """\
-bash
-
-set -e # Exit if a tool returns a non-zero status/exit code
-set -u # Treat unset variables and parameters as an error
-set -o pipefail # Returns the status of the last command to exit with a non-zero status or zero if all successfully execute
-set -C # No clobber - prevent output redirection from overwriting files.
-"""
+process.shell = [
+    "bash",
+    "-C",         // No clobber - prevent output redirection from overwriting files.
+    "-e",         // Exit if a tool returns a non-zero status/exit code
+    "-u",         // Treat unset variables and parameters as an error
+    "-o",         // Returns the status of the last command to exit..
+    "pipefail"    //   ..with a non-zero status or zero if all successfully execute
+]
 
 profiles {
 


### PR DESCRIPTION
Fixes warning about

```
WARN: Directive `process.shell` cannot contain new-line characters - offending value: [bash
```