### PR TITLE
Increase memory allocation to Bam2bed_sort

### DIFF
--- a/configs/modules.config
+++ b/configs/modules.config
@@ -461,9 +461,9 @@ process {
 
     withName: 'SCAFFOLD_CURATION:BAM2BED_SORT' {
         ext.prefix = { "${bam.head().getBaseName(1)}" }
-        ext.args   = '-u -F0x400 -h'        // arguments for samtools view
-        ext.args2  = '-S50G -T \$PWD'       // arguments for sort
-        ext.args3  = { "${params.hic_map_qv}" }  // min hic map quality
+        ext.args   = '-u -F0x400 -h'                           // arguments for samtools view
+        ext.args2  = { "-S${task.memory.toGiga()}G -T \$PWD" } // arguments for sort
+        ext.args3  = { "${params.hic_map_qv}" }                // min hic map quality
     }
     withName: 'SCAFFOLD_CURATION:COOLER_CLOAD' {
         ext.prefix = { "${pairs.head().getBaseName(1)}" }

--- a/configs/tool_resources.config
+++ b/configs/tool_resources.config
@@ -160,6 +160,10 @@ process {
         memory     = 10.GB
     }
 
+    withName: 'SCAFFOLD_CURATION:BAM2BED_SORT' {
+        memory     = 50.GB
+    }
+
     withName: 'PRETEXTMAP' {
         memory     = 30.GB
     }


### PR DESCRIPTION
Increases base memory allocation to 50.G and scales memory with task.memory.