### PR TITLE
Change toInteger to toLong to fit large genome sizes

### DIFF
--- a/configs/tool_resources.config
+++ b/configs/tool_resources.config
@@ -7,9 +7,9 @@ process {
 
     // EVALUATE ASSEMBLIES
     withName: 'BUSCO' {
-        time   = { meta.sample.genome_size.toInteger() > 3000000000 ? 4.d : 2.d }
-        cpus   = { meta.sample.genome_size.toInteger() > 3000000000 ? 40 : 30 }
-        memory = { meta.sample.genome_size.toInteger() > 3000000000 ? 230.GB : 128.GB }
+        time   = { meta.sample.genome_size.toLong() > 3000000000 ? 4.d : 2.d }
+        cpus   = { meta.sample.genome_size.toLong() > 3000000000 ? 40 : 30 }
+        memory = { meta.sample.genome_size.toLong() > 3000000000 ? 230.GB : 128.GB }
     }
 
     // FCS
@@ -30,15 +30,15 @@ process {
     // runs single threaded but uses 3 decompression and 8 compression threads by default
     // the runtime heavily depends on the HiC file and potentially on IO-load
     withName: 'PAIRTOOLS_PARSE' {
-        time   = { meta.sample.genome_size.toInteger() > 3000000000 ? 7.d : 2.d }
+        time   = { meta.sample.genome_size.toLong() > 3000000000 ? 7.d : 2.d }
         cpus   = 12
-        memory = { meta.sample.genome_size.toInteger() > 3000000000 ? 128.GB : 64.GB }
+        memory = { meta.sample.genome_size.toLong() > 3000000000 ? 128.GB : 64.GB }
     }
 
     withName: 'PAIRTOOLS_SORT' {
-        time   = { meta.sample.genome_size.toInteger() > 3000000000 ? 7.d : 2.d }
-        cpus   = { meta.sample.genome_size.toInteger() > 3000000000 ? 32 : 16 }
-        memory = { meta.sample.genome_size.toInteger() > 3000000000 ? 230.GB : 128.GB }
+        time   = { meta.sample.genome_size.toLong() > 3000000000 ? 7.d : 2.d }
+        cpus   = { meta.sample.genome_size.toLong() > 3000000000 ? 32 : 16 }
+        memory = { meta.sample.genome_size.toLong() > 3000000000 ? 230.GB : 128.GB }
     }
 
     withName: 'PAIRTOOLS_MERGE' {
@@ -48,111 +48,111 @@ process {
     }
 
     withName: 'PAIRTOOLS_DEDUP' {
-        time   = { meta.sample.genome_size.toInteger() > 3000000000 ? 2.d : 1.d }
-        cpus   = { meta.sample.genome_size.toInteger() > 3000000000 ? 16 : 12 }
-        memory = { meta.sample.genome_size.toInteger() > 3000000000 ? 128.GB : 64.GB }
+        time   = { meta.sample.genome_size.toLong() > 3000000000 ? 2.d : 1.d }
+        cpus   = { meta.sample.genome_size.toLong() > 3000000000 ? 16 : 12 }
+        memory = { meta.sample.genome_size.toLong() > 3000000000 ? 128.GB : 64.GB }
     }
 
     withName: 'PAIRTOOLS_SPLIT' {
-        time   = { meta.sample.genome_size.toInteger() > 3000000000 ? 2.d : 1.d }
-        cpus   = { meta.sample.genome_size.toInteger() > 3000000000 ? 32 : 16 }
-        memory = { meta.sample.genome_size.toInteger() > 3000000000 ? 128.GB : 64.GB }
+        time   = { meta.sample.genome_size.toLong() > 3000000000 ? 2.d : 1.d }
+        cpus   = { meta.sample.genome_size.toLong() > 3000000000 ? 32 : 16 }
+        memory = { meta.sample.genome_size.toLong() > 3000000000 ? 128.GB : 64.GB }
     }
 
     withName: 'YAHS' {
-        time   = { meta.sample.genome_size.toInteger() > 3000000000 ? 12.h : 8.h }
+        time   = { meta.sample.genome_size.toLong() > 3000000000 ? 12.h : 8.h }
         cpus   = 1
-        memory = { meta.sample.genome_size.toInteger() > 3000000000 ? 96.GB : 12.GB }
+        memory = { meta.sample.genome_size.toLong() > 3000000000 ? 96.GB : 12.GB }
     }
 
     withName: 'FASTK_FASTK' {
-        time   = { meta.sample.genome_size.toInteger() > 3000000000 ? 2.d : 1.d }
-        cpus   = { meta.sample.genome_size.toInteger() > 3000000000 ? 72 : 36 }
-        memory = { meta.sample.genome_size.toInteger() > 3000000000 ? 72.GB : 36.GB }
+        time   = { meta.sample.genome_size.toLong() > 3000000000 ? 2.d : 1.d }
+        cpus   = { meta.sample.genome_size.toLong() > 3000000000 ? 72 : 36 }
+        memory = { meta.sample.genome_size.toLong() > 3000000000 ? 72.GB : 36.GB }
     }
 
     withName: 'FASTK_MERGE' {
-        time   = { meta.sample.genome_size.toInteger() > 3000000000 ? 1.d : 8.h }
-        cpus   = { meta.sample.genome_size.toInteger() > 3000000000 ? 72 : 36 }
-        memory = { meta.sample.genome_size.toInteger() > 3000000000 ? 96.GB : 30.GB }
+        time   = { meta.sample.genome_size.toLong() > 3000000000 ? 1.d : 8.h }
+        cpus   = { meta.sample.genome_size.toLong() > 3000000000 ? 72 : 36 }
+        memory = { meta.sample.genome_size.toLong() > 3000000000 ? 96.GB : 30.GB }
     }
 
     withName: 'MERYL_COUNT' {
-        time   = { meta.sample.genome_size.toInteger() > 3000000000 ? 2.d : 1.d }
-        cpus   = { meta.sample.genome_size.toInteger() > 3000000000 ? 72 : 24 }
-        memory = { meta.sample.genome_size.toInteger() > 3000000000 ? 288.GB : 96.GB }
+        time   = { meta.sample.genome_size.toLong() > 3000000000 ? 2.d : 1.d }
+        cpus   = { meta.sample.genome_size.toLong() > 3000000000 ? 72 : 24 }
+        memory = { meta.sample.genome_size.toLong() > 3000000000 ? 288.GB : 96.GB }
     }
     // MERYL_UNIONSUM does not scale well with more threads
     withName: 'MERYL_UNIONSUM' {
-        time   = { meta.sample.genome_size.toInteger() > 3000000000 ? 12.h : 8.h }
-        cpus   = { meta.sample.genome_size.toInteger() > 3000000000 ? 48 : 16 }
-        memory = { meta.sample.genome_size.toInteger() > 3000000000 ? 96.GB : 64.GB }
+        time   = { meta.sample.genome_size.toLong() > 3000000000 ? 12.h : 8.h }
+        cpus   = { meta.sample.genome_size.toLong() > 3000000000 ? 48 : 16 }
+        memory = { meta.sample.genome_size.toLong() > 3000000000 ? 96.GB : 64.GB }
     }
 
     withName: 'MERQURY' {
-        time   = { meta.sample.genome_size.toInteger() > 3000000000 ? 12.h : 8.h }
-        cpus   = { meta.sample.genome_size.toInteger() > 3000000000 ? 48 : 16 }
-        memory = { meta.sample.genome_size.toInteger() > 3000000000 ? 128.GB : 96.GB }
+        time   = { meta.sample.genome_size.toLong() > 3000000000 ? 12.h : 8.h }
+        cpus   = { meta.sample.genome_size.toLong() > 3000000000 ? 48 : 16 }
+        memory = { meta.sample.genome_size.toLong() > 3000000000 ? 128.GB : 96.GB }
     }
 
     withName: 'MERQURYFK_MERQURYFK' {
-        time   = { meta.sample.genome_size.toInteger() > 3000000000 ? 8.h : 4.h }
-        cpus   = { meta.sample.genome_size.toInteger() > 3000000000 ? 64 : 32 }
-        memory = { meta.sample.genome_size.toInteger() > 3000000000 ? 96.GB : 64.GB }
+        time   = { meta.sample.genome_size.toLong() > 3000000000 ? 8.h : 4.h }
+        cpus   = { meta.sample.genome_size.toLong() > 3000000000 ? 64 : 32 }
+        memory = { meta.sample.genome_size.toLong() > 3000000000 ? 96.GB : 64.GB }
     }
 
     withName: 'MERQURYFK_PLOIDYPLOT' {
-        time   = { meta.sample.genome_size.toInteger() > 3000000000 ? 8.h : 4.h }
-        cpus   = { meta.sample.genome_size.toInteger() > 3000000000 ? 96 : 64 }
-        memory = { meta.sample.genome_size.toInteger() > 3000000000 ? 192.GB : 96.GB }
+        time   = { meta.sample.genome_size.toLong() > 3000000000 ? 8.h : 4.h }
+        cpus   = { meta.sample.genome_size.toLong() > 3000000000 ? 96 : 64 }
+        memory = { meta.sample.genome_size.toLong() > 3000000000 ? 192.GB : 96.GB }
     }
 
     withName: 'MINIMAP2_ALIGN_READS' {
-        time   = { meta.sample.genome_size.toInteger() > 3000000000 ? 1.d : 12.h }
-        cpus   = { meta.sample.genome_size.toInteger() > 3000000000 ? 64 : 32 }
-        memory = { meta.sample.genome_size.toInteger() > 3000000000 ? 64.GB : 32.GB }
+        time   = { meta.sample.genome_size.toLong() > 3000000000 ? 1.d : 12.h }
+        cpus   = { meta.sample.genome_size.toLong() > 3000000000 ? 64 : 32 }
+        memory = { meta.sample.genome_size.toLong() > 3000000000 ? 64.GB : 32.GB }
     }
 
     withName: 'MINIMAP2_ALIGN_ASSEMBLY_PRIMARY' {
-        time   = { meta.sample.genome_size.toInteger() > 3000000000 ? 2.d : 1.d }
-        cpus   = { meta.sample.genome_size.toInteger() > 3000000000 ? 64 : 32 }
-        memory = { meta.sample.genome_size.toInteger() > 3000000000 ? 128.GB : 64.GB }
+        time   = { meta.sample.genome_size.toLong() > 3000000000 ? 2.d : 1.d }
+        cpus   = { meta.sample.genome_size.toLong() > 3000000000 ? 64 : 32 }
+        memory = { meta.sample.genome_size.toLong() > 3000000000 ? 128.GB : 64.GB }
     }
 
     withName: 'BWAMEM2_INDEX' {
-        time   = { meta.sample.genome_size.toInteger() > 3000000000 ? 1.d : 12.h }
+        time   = { meta.sample.genome_size.toLong() > 3000000000 ? 1.d : 12.h }
         cpus   = 1
-        memory = { meta.sample.genome_size.toInteger() > 3000000000 ? 256.GB : 60.GB }
+        memory = { meta.sample.genome_size.toLong() > 3000000000 ? 256.GB : 60.GB }
     }
 
     withName: 'BWAMEM2_MEM' {
-        time   = { meta.sample.genome_size.toInteger() > 3000000000 ? 1.d : 12.h }
-        cpus   = { meta.sample.genome_size.toInteger() > 3000000000 ? 96 : 64 }
-        memory = { meta.sample.genome_size.toInteger() > 3000000000 ? 596.GB : 120.GB }
+        time   = { meta.sample.genome_size.toLong() > 3000000000 ? 1.d : 12.h }
+        cpus   = { meta.sample.genome_size.toLong() > 3000000000 ? 96 : 64 }
+        memory = { meta.sample.genome_size.toLong() > 3000000000 ? 596.GB : 120.GB }
     }
 
     withName: 'HIFIASM' {
-        time   = { meta.sample.genome_size.toInteger() > 3000000000 ? 2.d : 1.d }
-        cpus   = { meta.sample.genome_size.toInteger() > 3000000000 ? 96 : 46 }
-        memory = { meta.sample.genome_size.toInteger() > 3000000000 ? 596.GB : 128.GB }
+        time   = { meta.sample.genome_size.toLong() > 3000000000 ? 2.d : 1.d }
+        cpus   = { meta.sample.genome_size.toLong() > 3000000000 ? 96 : 46 }
+        memory = { meta.sample.genome_size.toLong() > 3000000000 ? 596.GB : 128.GB }
     }
 
     withName: 'PURGEDUPS_PURGEDUPS_PRIMARY' {
-        time   = { meta.sample.genome_size.toInteger() > 3000000000 ? 12.h : 8.h }
+        time   = { meta.sample.genome_size.toLong() > 3000000000 ? 12.h : 8.h }
         cpus   = 1
-        memory = { meta.sample.genome_size.toInteger() > 3000000000 ? 256.GB : 30.GB }
+        memory = { meta.sample.genome_size.toLong() > 3000000000 ? 256.GB : 30.GB }
     }
 
     withName: 'PURGEDUPS_PBCSTAT' {
-        time   = { meta.sample.genome_size.toInteger() > 3000000000 ? 2.h : 1.h }
+        time   = { meta.sample.genome_size.toLong() > 3000000000 ? 2.h : 1.h }
         cpus   = 1
-        memory = { meta.sample.genome_size.toInteger() > 3000000000 ? 16.GB : 8.GB }
+        memory = { meta.sample.genome_size.toLong() > 3000000000 ? 16.GB : 8.GB }
     }
     // scales linearly with genome size
     withName: 'GFASTATS' {
-        time   = { meta.sample.genome_size.toInteger() > 3000000000 ? 4.h : 1.h }
+        time   = { meta.sample.genome_size.toLong() > 3000000000 ? 4.h : 1.h }
         cpus   = 1
-        memory = { meta.sample.genome_size.toInteger() > 3000000000 ? 64.GB : 8.GB }
+        memory = { meta.sample.genome_size.toLong() > 3000000000 ? 64.GB : 8.GB }
     }
 
     withName: 'SCAFFOLD_CURATION:SAMTOOLS_MERGE_(HIFI|HIC)' {


### PR DESCRIPTION
Resolves issues #148 and #265

The genome sizes are larger than fit in a 32-bit integer ( max value: 2,147,483,647 ). 
Using `toLong` instead of `toInteger` which is 64-bit ( max value: 9,223,372,036,854,775,807 ) should resolve this issue.