### PR TITLE
Add offline when lineage db path given to busco

### DIFF
--- a/configs/modules.config
+++ b/configs/modules.config
@@ -520,7 +520,10 @@ process {
     withName: 'BUSCO' {
         tag        = { "${meta.assembly.build}-${lineage}" }
         ext.prefix = { "${meta.assembly.build}-${lineage}" }
-        ext.args   = '--tar'
+        ext.args   = { [
+            '--tar',
+            params.busco.lineages_db_path ? "--offline" : ""
+        ].minus("").join(" ") }
         publishDir = [
             path: {
                 [


### PR DESCRIPTION
When the path to lineage data sets is provided busco will attempt to overwrite it, so `--offline` mode needs to be enabled. This has been removed in a more recent version of the busco module. 