### PR TITLE
Provide singularity cacheDir, fixes #276

### DIFF
--- a/tests/nextflow.config
+++ b/tests/nextflow.config
@@ -54,7 +54,7 @@ profiles {
 
     singularity {
         singularity.enabled  = true
-        singularity.cacheDir    = "${projectDir}/work/singularity"
+        singularity.cacheDir    = "${projectDir}/.nf-test/singularity"
     }
 
 }


### PR DESCRIPTION
Provide the default singularity cacheDir explicitly, this avoids re-caching for each `nf-test` run.