### PR TITLE
Add publishDir for Samtools_Fasta

### DIFF
--- a/configs/modules.config
+++ b/configs/modules.config
@@ -55,6 +55,11 @@ process {
     withName: 'PREPARE_INPUT:SAMTOOLS_FASTA' {
         tag        = { "$meta.id:$bam.baseName" }
         ext.prefix = { bam.baseName }
+        publishDir = [
+            path: { "$params.outdir/$stage.preprocess/converted_bam_to_fasta" },
+            mode: params.publish_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
     }
     withName: 'MERGE_PACBIO' {
         ext.prefix = { "${meta.id}_mergedpb.fasta.gz" }


### PR DESCRIPTION
The `fasta.gz` is needed for curation pretext.