### PR TITLE
Reduce FCSGX memory to fit on standard node

### DIFF
--- a/configs/tool_resources.config
+++ b/configs/tool_resources.config
@@ -22,7 +22,7 @@ process {
         // RUNGX should run in less than an hour when using the ramdisk.
         maxForks   = 1
         cpus       = 20
-        memory     = 1024.GB
+        memory     = 600.GB
         time       = 1.h
     }
 


### PR DESCRIPTION
When Pelle was first set up, only half the memory was permitted to be accessed from /dev/shm. It's been changed so that the full memory is available, which will now allow the 500GB database to be written to shared memory.

Resolves #311 