### PR TITLE
Use pairtools environment yaml

### DIFF
--- a/modules/local/pairtools/environment.yml
+++ b/modules/local/pairtools/environment.yml
@@ -5,4 +5,6 @@ channels:
   - bioconda
 dependencies:
   - bioconda::pairtools=1.1.0
+    # Pinning numpy to 1.23 until https://github.com/open2c/pairtools/issues/170 is resolved
+    # Not an issue with the biocontainers because they were built prior to numpy 1.24
   - conda-forge::numpy=1.23

--- a/modules/local/pairtools/main.nf
+++ b/modules/local/pairtools/main.nf
@@ -2,9 +2,7 @@ process PAIRTOOLS {
     tag "${meta.id}"
     label 'process_high'
 
-    // Pinning numpy to 1.23 until https://github.com/open2c/pairtools/issues/170 is resolved
-    // Not an issue with the biocontainers because they were built prior to numpy 1.24
-    conda "bioconda::pairtools=1.1.0 conda-forge::numpy=1.23"
+    conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/pairtools:1.1.0--py39hd5a99d8_2' :
         'biocontainers/pairtools:1.1.0--py39hd5a99d8_2' }"


### PR DESCRIPTION
The pairtools conda directive directly supplies the package names, although there is an environment.yml. 

- Use environment.yml
- Move comment to environment.yml